### PR TITLE
<fix>[ipv6-addr]: fix ipv6 addr lost and dadfailed

### DIFF
--- a/data/file-lists/sysctl.conf
+++ b/data/file-lists/sysctl.conf
@@ -77,3 +77,7 @@ net.ipv4.conf.all.arp_filter = 1
 net.ipv4.conf.default.arp_filter = 1
 net.ipv4.ip_nonlocal_bind = 1
 net.ipv6.ip_nonlocal_bind = 1
+net.ipv6.conf.all.keep_addr_on_down = 1
+net.ipv6.conf.default.keep_addr_on_down = 1
+net.ipv6.conf.all.accept_dad = 0
+net.ipv6.conf.default.accept_dad = 0

--- a/data/hooks/12_set_ipv6_kernel_args.sh
+++ b/data/hooks/12_set_ipv6_kernel_args.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# set all,default value
+sysctl -p
+
+# set specific nic value
+NIC_NAMES=$(ls /sys/class/net)
+for nic in $NIC_NAMES; do
+  echo 0 > /proc/sys/net/ipv6/conf/$nic/accept_dad
+  echo 1 > /proc/sys/net/ipv6/conf/$nic/keep_addr_on_down
+done

--- a/zvrboot/zvrboot.go
+++ b/zvrboot/zvrboot.go
@@ -424,6 +424,18 @@ func configureVyos() {
 		if nic.ip6 != "" {
 			setNicTree.SetfWithoutCheckExisting("interfaces ethernet %s address %s", nic.name, fmt.Sprintf("%s/%d", nic.ip6, nic.prefixLength))
 		}
+
+		//set kernel arguments for specific nic
+		err := os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/keep_addr_on_down", nic.name), []byte("1"), 0644)
+		if err != nil {
+			log.Warningf("enable nic %s keep_addr_on_down failed: %s!", nic.name, err)
+		}
+
+		err = os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_dad", nic.name), []byte("0"), 0644)
+		if err != nil {
+			log.Warningf("disable nic %s accept_dad failed: %s!", nic.name, err)
+		}
+
 		setNicTree.Setf("interfaces ethernet %s duplex auto", nic.name)
 		setNicTree.SetNicSmpAffinity(nic.name, "auto")
 		setNicTree.Setf("interfaces ethernet %s speed auto", nic.name)

--- a/zvrboot/zvrboot_utils.go
+++ b/zvrboot/zvrboot_utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -171,6 +172,18 @@ func configureNicInfo(nic *utils.NicInfo) {
 	var err error
 	// TODO ....
 	//setNicTree.SetNicSmpAffinity(nic.name, "auto")
+
+	//set kernel arguments for specific nic
+	err = os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/keep_addr_on_down", nic.Name), []byte("1"), 0644)
+	if err != nil {
+		log.Warningf("enable nic %s keep_addr_on_down failed: %s!", nic.Name, err)
+	}
+
+	err = os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_dad", nic.Name), []byte("0"), 0644)
+	if err != nil {
+		log.Warningf("disable nic %s accept_dad failed: %s!", nic.Name, err)
+	}
+
 	utils.SetNicOption(nic.Name)
 	err = utils.IpLinkSetUp(nic.Name)
 	utils.Assertf(err == nil, "IpLinkSetUp[%s] error: %s", nic.Name, err)


### PR DESCRIPTION
Resolves: ZSTAC-61458

Change-Id: I616b686d6d7863776b767568727461717770676d

Signed-off-by: zhangjianjun <jianjun.zhang@zstack.io>

sync from gitlab !798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为IPv6设置添加了地址处理和重复地址检测（DAD）配置。
  - 添加了Bash脚本以设置IPv6内核参数。
  - 在`configureVyos`函数中，添加了针对特定网络接口卡（NIC）的内核参数设置。
  - `zvrboot_utils.go`中的`configureNicInfo`函数现在设置了特定NIC的内核参数。

- **Bug修复**
  - 修复了IPv6配置脚本，确保正确应用网络接口的设置。

- **改进**
  - 更新了网络接口的内核参数配置，以优化网络性能和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->