### PR TITLE
<fix>[ipsec]: fix ipsec upgrade dir error

### DIFF
--- a/plugin/ipsec.go
+++ b/plugin/ipsec.go
@@ -531,7 +531,11 @@ func updateIPsecConnectionHandler(ctx *server.CommandContext) interface{} {
 func updateIPsecVersionHandler(ctx *server.CommandContext) interface{} {
 	cmd := &updateIpsecVersionCmd{}
 	ctx.GetCommand(cmd)
-	return updateIpsecVersion(cmd)
+	err := updateIpsecVersion(cmd)
+	if err != nil {
+		panic(err)
+	}
+	return nil
 }
 
 type ipsecVersionMgr struct {
@@ -591,7 +595,6 @@ func updateOriginVersion(version string) error {
 		}
 
 		log.Infof("TEMP: updateOriginVersion create origin dir %s.", versionPath)
-		return nil
 	}
 
 	if err := utils.CopyFile(filepath.Join(originPath, ipsec_strongswan_upgrade_cmd),
@@ -799,7 +802,13 @@ func updateIpsecVersion(cmd *updateIpsecVersionCmd) error {
 		return fmt.Errorf("version %s is not support", cmd.Version)
 	}
 
-	err := ipsecVerMgr.currentDriver.DeleteIpsecConns(&deleteIPsecCmd{cmd.Infos})
+	//create origin ipsec upgrade dir
+	_, err := getCurrentVersionInuse()
+	if err != nil {
+		return err
+	}
+
+	err = ipsecVerMgr.currentDriver.DeleteIpsecConns(&deleteIPsecCmd{cmd.Infos})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves: ZSTAC-56437

Change-Id:I6868771s5xa187532fs345c4z62xdbaa08e2as65

sync from gitlab !807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在更新IPsec版本时增加了当前版本检查，以确保连接安全。
  
- **错误修复**
  - 现在如果更新IPsec版本时发生错误，系统将触发紧急停止以保护数据安全。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->