### PR TITLE
<fix>[snat]: postrouing can not use -i option, use mark instead

### DIFF
--- a/plugin/snat.go
+++ b/plugin/snat.go
@@ -460,6 +460,7 @@ func syncSnatByIptables(Snats []SnatInfo, state bool) {
 	err := table.Apply()
 	utils.PanicOnError(err)
 
+	mangleTable.AddIpTableRules(setMarkRules)
 	checkSaveMarkRule(mangleTable)
 	err = mangleTable.Apply()
 	utils.PanicOnError(err)


### PR DESCRIPTION
Resolves: ZSTAC-75148

Change-Id: I6b696879636e6e6b6f796f636c73647865757765

Signed-off-by: zhangjianjun <jianjun.zhang@zstack.io>

sync from gitlab !989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 修复了 SNAT 规则同步时未正确添加标记规则的问题，确保标记规则能够被正确应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->