### PR TITLE
<fix>[zvrboot]: fix allowPasswordAuth error <description>

### DIFF
--- a/zvrboot/zvrboot_utils.go
+++ b/zvrboot/zvrboot_utils.go
@@ -132,8 +132,8 @@ func configureSshServer() {
 	address := mgmtNic.Ip
 	utils.Assert(address != "", "cannot find eth0 ip address in bootstrap info")
 	passwordAuthentication := "no"
-	if _, ok := utils.BootstrapInfo["publicKey"].(string); ok {
-		passwordAuthentication = utils.BootstrapInfo["publicKey"].(string)
+	if _, ok := utils.BootstrapInfo["allowPasswordAuth"].(string); ok {
+		passwordAuthentication = utils.BootstrapInfo["allowPasswordAuth"].(string)
 	}
 
 	sshInfo := utils.NewSshServer().SetListen(address).SetPorts(int(sshport)).SetKeys(sshkey)


### PR DESCRIPTION
Resolves: ZSTAC-71842

Change-Id: I7375656478637376757266796273736e6c787977

sync from gitlab !1000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 修正了SSH服务器密码认证的配置逻辑，确保根据“allowPasswordAuth”参数正确设置密码认证选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->