### PR TITLE
<fix>[ospf]:reconnection does not affect ospf

### DIFF
--- a/plugin/auxiliary.go
+++ b/plugin/auxiliary.go
@@ -398,10 +398,6 @@ func configureOspfByVtysh(cmd *setOspfCmd) {
 	utils.PanicOnError(err)
 
 	if isOspfConfigEqual(oldCmd, newCmd) {
-		return
-	}
-
-	if isOspfConfigEqual(oldCmd, newCmd) {
 		log.Debugf("ospf config is equal")
 		return
 	}
@@ -463,6 +459,8 @@ func parseRunningOspfConfig(output []byte) (*utils.VtyshOspfCmd, error) {
 		if matches := areaStubRegex.FindStringSubmatch(line); len(matches) > 1 {
 			stubAreas[matches[1]] = true
 			v.SetArea(matches[1], "Stub", string(None))
+		} else if netmatches := networkRegex.FindStringSubmatch(line); len(netmatches) > 1 {
+			v.SetArea(netmatches[2], "Standard", string(None))
 		}
 	}
 
@@ -553,8 +551,24 @@ func isOspfConfigEqual(old, new *utils.VtyshOspfCmd) bool {
 	if len(old.NetworkCmd) != len(new.NetworkCmd) {
 		return false
 	}
-	for k, oldNetwork := range old.NetworkCmd {
-		if oldNetwork != new.NetworkCmd[k] {
+	newNetworkMatched := make([]bool, len(new.NetworkCmd))
+
+	for _, oldNetwork := range old.NetworkCmd {
+		found := false
+		for j, newNetwork := range new.NetworkCmd {
+			if !newNetworkMatched[j] && oldNetwork == newNetwork {
+				newNetworkMatched[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	for _, matched := range newNetworkMatched {
+		if !matched {
 			return false
 		}
 	}


### PR DESCRIPTION
Resolves: ZSTAC-72214

Change-Id: I78686c7068777a78787468707665746677616578

sync from gitlab !1006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 优化了OSPF网络命令的比对方式，现在可忽略顺序判断配置是否一致，提升了配置变更检测的准确性。
  * 修复了对OSPF配置解析时对标准区域的识别与处理，增强了配置解析的完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->