### PR TITLE
<fix>[data]: remove /usr/local/zstack/.zstack_runner <description>

### DIFF
--- a/mk_euler2203_with_zsn.sh
+++ b/mk_euler2203_with_zsn.sh
@@ -96,6 +96,8 @@ rm /usr/local/zstack/.zstack_runner
 
 mkdir-p /home/zstack/zvr/data/
 tar-in $DATA /home/zstack/zvr/data/ compress:gzip
+
+rm /usr/local/zstack/.zstack_runner
 _EOF_
 
 #/bin/rm -rf $tmpdir


### PR DESCRIPTION
Resolves: ZSTAC-76406

Change-Id: I786166746a70786177766863746f7776616f7276

sync from gitlab !1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 无

- Bug 修复
  - 在镜像制作流程中增加一次 guest 环境的二次清理：解包后额外删除 /usr/local/zstack/.zstack_runner，防止残留文件进入镜像，提升构建一致性与稳定性，降低潜在运行风险。宿主侧逻辑未变，更改不影响现有上传与挂载流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->