### PR TITLE
<fix>[snat]: refactor private nic snat rule

### DIFF
--- a/plugin/configure_nic.go
+++ b/plugin/configure_nic.go
@@ -235,8 +235,6 @@ func configureNicFirewall(nics []utils.NicInfo) {
 			if nic.Category == "Private" {
 				err := utils.InitNicFirewall(nicname, nic.Ip, false, utils.IPTABLES_ACTION_REJECT)
 				utils.PanicOnError(err)
-
-				utils.AddSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
 			} else {
 				err := utils.InitNicFirewall(nicname, nic.Ip, true, utils.IPTABLES_ACTION_REJECT)
 				utils.PanicOnError(err)
@@ -244,7 +242,11 @@ func configureNicFirewall(nics []utils.NicInfo) {
 
 			if nic.Category == "Private" {
 				log.Debug("start configure LB firewall rule for new added nic")
-				configureLBFirewallRuleByIpTables(nicname)
+				err := configureLBFirewallRuleByIpTables(nicname)
+				utils.PanicOnError(err)
+
+				err = utils.AddSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
+				utils.PanicOnError(err)
 			}
 		}
 	} else {
@@ -310,6 +312,17 @@ func configureNicFirewall(nics []utils.NicInfo) {
 			if nic.Category == "Private" {
 				log.Debug("start configure LB firewall rule")
 				configureLBFirewallRuleByVyos(tree, nicname)
+
+				// add private SNAT rule
+				nicNo, _ := utils.GetNicNumber(nicname)
+				ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
+				address, _ := utils.GetNetworkNumber(nic.Ip, nic.Netmask)
+				tree.SetSnatWithRuleNumber(ruleNo,
+					fmt.Sprintf("outbound-interface %s", nicname),
+					fmt.Sprintf("source address %s", address),
+					"destination address !224.0.0.0/8",
+					fmt.Sprintf("translation address %s", nic.Ip),
+				)
 			}
 		}
 
@@ -498,11 +511,32 @@ func RemoveNic(cmd *ConfigureNicCmd) interface{} {
 				}
 			}, 5, 1)
 			utils.PanicOnError(err)
+
 			tree.Deletef("interfaces ethernet %s", nicname)
 			if utils.IsSkipVyosIptables() {
 				err := utils.DestroyNicFirewall(nicname)
 				utils.PanicOnError(err)
+
+				err = utils.RemoveSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
+				utils.PanicOnError(err)
 			} else {
+				// delete private SNAT rule (VyOS config) added during configureNicFirewall
+				address, _ := utils.GetNetworkNumber(nic.Ip, nic.Netmask)
+				rules := tree.Get("nat source rule")
+				if rules != nil {
+					for _, r := range rules.Children() {
+						outIf := r.Get("outbound-interface")
+						sAddr := r.Get("source address")
+						tAddr := r.Get("translation address")
+						if outIf != nil && outIf.Value() == nicname &&
+							sAddr != nil && sAddr.Value() == address &&
+							tAddr != nil && tAddr.Value() == nic.Ip {
+							r.Delete()
+							break
+						}
+					}
+				}
+
 				tree.Deletef("firewall name %s.in", nicname)
 				tree.Deletef("firewall name %s.local", nicname)
 			}
@@ -521,12 +555,14 @@ func RemoveNic(cmd *ConfigureNicCmd) interface{} {
 				}
 			}, 5, 1)
 			utils.PanicOnError(err)
+
 			err = utils.DestroyNicFirewall(nicname)
 			utils.PanicOnError(err)
 			err = utils.IpAddrFlush(nicname)
 			utils.PanicOnError(err)
 
-			utils.RemoveSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
+			err = utils.RemoveSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
+			utils.PanicOnError(err)
 		}
 	}
 

--- a/plugin/snat.go
+++ b/plugin/snat.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
 	"zstack-vyos/server"
 	"zstack-vyos/utils"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -47,8 +48,6 @@ type SetSnatStateCmd struct {
 type setNetworkServiceRsp struct {
 	ServiceStatus string `json:"serviceStatus"`
 }
-
-var SNAT_RULE_NUMBER = 9999
 
 func getNicSNATRuleNumberByConfig(tree *server.VyosConfigTree, snat SnatInfo, checkPubIp bool) (pubNicRuleNo int, priNicRuleNo int) {
 	rules := tree.Get("nat source rule")
@@ -96,12 +95,6 @@ func getNicSNATRuleNumberByConfig(tree *server.VyosConfigTree, snat SnatInfo, ch
 	return ruleId3, ruleId4
 }
 
-func getNicSNATRuleNumber(nicNo int) (pubNicRuleNo int, priNicRuleNo int) {
-	pubNicRuleNo = SNAT_RULE_NUMBER - nicNo*2
-	priNicRuleNo = pubNicRuleNo - 1
-	return
-}
-
 // Deprecated
 func setSnatHandler(ctx *server.CommandContext) interface{} {
 	cmd := &SetSnatCmd{}
@@ -141,7 +134,7 @@ func SetSnat(cmd *SetSnatCmd) interface{} {
 		// make source nat rule as the latest rule
 		// in case there are EIP rules
 		tree := server.NewParserFromShowConfiguration().Tree
-		pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumber(nicNumber)
+		pubNicRuleNo, _ := utils.GetPublicNicSNATRuleNumber(nicNumber)
 		setted := false
 		if !hasRuleNumberForAddress(tree, address, pubNicRuleNo) {
 			tree.SetSnatWithRuleNumber(pubNicRuleNo,
@@ -149,16 +142,6 @@ func SetSnat(cmd *SetSnatCmd) interface{} {
 				fmt.Sprintf("source address %v", address),
 				"destination address !224.0.0.0/8",
 				fmt.Sprintf("translation address %s", s.PublicIp),
-			)
-			setted = true
-		}
-
-		if !hasRuleNumberForAddress(tree, address, priNicRuleNo) {
-			tree.SetSnatWithRuleNumber(priNicRuleNo,
-				fmt.Sprintf("outbound-interface %s", inNic),
-				fmt.Sprintf("source address %v", address),
-				"destination address !224.0.0.0/8",
-				fmt.Sprintf("translation address %s", s.PrivateGatewayIp),
 			)
 			setted = true
 		}
@@ -185,8 +168,7 @@ func RemoveSnat(cmd *RemoveSnatCmd) interface{} {
 		for _, s := range cmd.NatInfo {
 			publicNic, err := utils.GetNicNameByMac(s.PublicNicMac)
 			utils.PanicOnError(err)
-			priNic, err := utils.GetNicNameByMac(s.PrivateNicMac)
-			utils.PanicOnError(err)
+
 			address, err := utils.GetNetworkNumber(s.PrivateNicIp, s.SnatNetmask)
 			utils.PanicOnError(err)
 
@@ -195,12 +177,6 @@ func RemoveSnat(cmd *RemoveSnatCmd) interface{} {
 			rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetOutNic(publicNic).SetSnatTargetIp(s.PublicIp)
 			table.RemoveIpTableRule([]*utils.IpTableRule{rule})
 
-			rule = utils.NewIpTableRule(utils.RULESET_SNAT.String())
-			rule.SetAction(utils.IPTABLES_ACTION_SNAT).SetComment(utils.SNATComment)
-			rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetSrcIpRange(fmt.Sprintf("! %s-%s", s.PrivateGatewayIp, s.PrivateGatewayIp)).
-				SetOutNic(priNic).SetSnatTargetIp(s.PublicIp)
-
-			table.RemoveIpTableRule([]*utils.IpTableRule{rule})
 		}
 
 		err := table.Apply()
@@ -209,18 +185,13 @@ func RemoveSnat(cmd *RemoveSnatCmd) interface{} {
 		tree := server.NewParserFromShowConfiguration().Tree
 
 		for _, s := range cmd.NatInfo {
-			pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumberByConfig(tree, s, false)
+			pubNicRuleNo, _ := getNicSNATRuleNumberByConfig(tree, s, false)
 			if rs := tree.Get(fmt.Sprintf("nat source rule %v", pubNicRuleNo)); rs == nil {
 				log.Debugf(fmt.Sprintf("nat source rule %v not found", pubNicRuleNo))
 			} else {
 				rs.Delete()
 			}
 
-			if rs := tree.Get(fmt.Sprintf("nat source rule %v", priNicRuleNo)); rs == nil {
-				log.Debugf(fmt.Sprintf("nat source rule %v not found", priNicRuleNo))
-			} else {
-				rs.Delete()
-			}
 		}
 		tree.Apply(false)
 	}
@@ -244,8 +215,7 @@ func setSnatStateByIptables(Snats []SnatInfo, state bool) {
 	for _, s := range Snats {
 		outNic, err := utils.GetNicNameByMac(s.PublicNicMac)
 		utils.PanicOnError(err)
-		inNic, err := utils.GetNicNameByMac(s.PrivateNicMac)
-		utils.PanicOnError(err)
+
 		address, err := utils.GetNetworkNumber(s.PrivateNicIp, s.SnatNetmask)
 		utils.PanicOnError(err)
 
@@ -254,13 +224,6 @@ func setSnatStateByIptables(Snats []SnatInfo, state bool) {
 		rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetOutNic(outNic).SetSnatTargetIp(s.PublicIp)
 		rules = append(rules, rule)
 
-		if state == false {
-			rule = utils.NewIpTableRule(utils.RULESET_SNAT.String())
-			rule.SetAction(utils.IPTABLES_ACTION_SNAT).SetComment(utils.SNATComment)
-			rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetSrcIpRange(fmt.Sprintf("! %s-%s", s.PrivateGatewayIp, s.PrivateGatewayIp)).
-				SetOutNic(inNic).SetSnatTargetIp(s.PublicIp)
-			rules = append(rules, rule)
-		}
 	}
 
 	if state == false {
@@ -272,12 +235,6 @@ func setSnatStateByIptables(Snats []SnatInfo, state bool) {
 	err := table.Apply()
 	utils.PanicOnError(err)
 
-	if state {
-		for _, s := range Snats {
-			inNic, _ := utils.GetNicNameByMac(s.PrivateNicMac)
-			utils.AddSnatRuleForPrivateNic(inNic, s.PrivateNicIp, s.SnatNetmask)
-		}
-	}
 }
 
 func syncSnatByIptables(Snats []SnatInfo, state bool) {
@@ -312,10 +269,6 @@ func syncSnatByIptables(Snats []SnatInfo, state bool) {
 	err := table.Apply()
 	utils.PanicOnError(err)
 
-	for _, s := range Snats {
-		inNic, _ := utils.GetNicNameByMac(s.PrivateNicMac)
-		utils.AddSnatRuleForPrivateNic(inNic, s.PrivateNicIp, s.SnatNetmask)
-	}
 }
 
 func applySnatRules(Snats []SnatInfo, state bool) bool {
@@ -332,22 +285,14 @@ func applySnatRules(Snats []SnatInfo, state bool) bool {
 		address, err := utils.GetNetworkNumber(s.PrivateNicIp, s.SnatNetmask)
 		utils.PanicOnError(err)
 
-		pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumberByConfig(tree, s, false)
+		pubNicRuleNo, _ := getNicSNATRuleNumberByConfig(tree, s, false)
 		if s.State == true {
-			newPubNicRuleNo, newPriNicRuleNo := getNicSNATRuleNumber(nicNumber)
-
-			for j := 1; ; j++ {
-				if tree.Getf("nat source rule %v", newPubNicRuleNo) == nil && tree.Getf("nat source rule %v", newPriNicRuleNo) == nil {
-					break
-				} else {
-					newPubNicRuleNo, newPriNicRuleNo = getNicSNATRuleNumber(nicNumber + j)
-				}
-			}
+			newPubNicRuleNo, _ := utils.GetPublicNicSNATRuleNumber(nicNumber)
 
 			if pubNicRuleNo == 0 {
 				pubNicRuleNo = newPubNicRuleNo
-				pubRs := tree.Getf("nat source rule %v", pubNicRuleNo)
-				if pubRs == nil {
+				pubRule := tree.Getf("nat source rule %v", pubNicRuleNo)
+				if pubRule == nil {
 					tree.SetSnatWithRuleNumber(pubNicRuleNo,
 						fmt.Sprintf("outbound-interface %s", outNic),
 						fmt.Sprintf("source address %s", address),
@@ -357,38 +302,16 @@ func applySnatRules(Snats []SnatInfo, state bool) bool {
 					update = true
 				}
 			}
-			if priNicRuleNo == 0 {
-				priNicRuleNo = newPriNicRuleNo
-				priRs := tree.Getf("nat source rule %v", priNicRuleNo)
-				if priRs == nil {
-					tree.SetSnatWithRuleNumber(priNicRuleNo,
-						fmt.Sprintf("outbound-interface %s", inNic),
-						fmt.Sprintf("source address %v", address),
-						"destination address !224.0.0.0/8",
-						fmt.Sprintf("translation address %s", s.PrivateGatewayIp),
-					)
-				}
-				update = true
-			}
+
 		} else {
-			pubNicRuleNo, priNicRuleNo = getNicSNATRuleNumberByConfig(tree, s, false)
+			pubNicRuleNo, _ = getNicSNATRuleNumberByConfig(tree, s, false)
 			if rs := tree.Getf("nat source rule %v", pubNicRuleNo); rs != nil {
 				update = true
 				rs.Delete()
 			}
 
-			if rs := tree.Getf("nat source rule %v", priNicRuleNo); rs != nil {
-				update = true
-				rs.Delete()
-			}
 		}
 
-		/* TO remove old rule before 5.3.0 */
-		_, priNicRuleNo = getNicSNATRuleNumberByConfig(tree, s, true)
-		if rs := tree.Getf("nat source rule %v", priNicRuleNo); rs != nil {
-			update = true
-			rs.Delete()
-		}
 	}
 
 	tree.Apply(false)
@@ -442,6 +365,82 @@ func SyncSnat(cmd *SyncSnatCmd) interface{} {
 			t := utils.ConnectionTrackTuple{IsNat: false, IsDst: true, Ip: cmd.Snats[0].PublicIp, Protocol: "",
 				PortStart: 0, PortEnd: 0}
 			t.CleanConnTrackConnection()
+		}
+	}
+
+	// ensure private SNAT rules exist when enabled:
+	// collect all unique private NICs and their CIDRs
+	type priInfo struct {
+		nicName string
+		nicIp   string
+		netmask string
+		addr    string
+	}
+	privates := make(map[string]priInfo) // key: private MAC
+	for _, s := range cmd.Snats {
+		if _, ok := privates[s.PrivateNicMac]; ok {
+			continue
+		}
+
+		// derive nic name, cidr and ip
+		inNic, err := utils.GetNicNameByMac(s.PrivateNicMac)
+		if err != nil || inNic == "" {
+			continue
+		}
+		address, err := utils.GetNetworkNumber(s.PrivateNicIp, s.SnatNetmask)
+		if err != nil || address == "" {
+			continue
+		}
+		privates[s.PrivateNicMac] = priInfo{
+			nicName: inNic,
+			nicIp:   s.PrivateNicIp,
+			netmask: s.SnatNetmask,
+			addr:    address,
+		}
+	}
+
+	// add missing private SNAT rules per mode
+	if utils.IsSkipVyosIptables() {
+		for _, p := range privates {
+			_ = utils.AddSnatRuleForPrivateNic(p.nicName, p.nicIp, p.netmask)
+		}
+	} else {
+		tree := server.NewParserFromShowConfiguration().Tree
+		updated := false
+		for _, p := range privates {
+			nicNo, err := utils.GetNicNumber(p.nicName)
+			if err != nil {
+				continue
+			}
+			ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
+			// scan existing nat source rules to see if one matches fields:
+			rules := tree.Get("nat source rule")
+			exists := false
+			if rules != nil {
+				for _, r := range rules.Children() {
+					outIf := r.Get("outbound-interface")
+					sAddr := r.Get("source address")
+					tAddr := r.Get("translation address")
+					if outIf != nil && outIf.Value() == p.nicName &&
+						sAddr != nil && sAddr.Value() == p.addr &&
+						tAddr != nil && tAddr.Value() == p.nicIp {
+						exists = true
+						break
+					}
+				}
+			}
+			if !exists {
+				tree.SetSnatWithRuleNumber(ruleNo,
+					fmt.Sprintf("outbound-interface %s", p.nicName),
+					fmt.Sprintf("source address %s", p.addr),
+					"destination address !224.0.0.0/8",
+					fmt.Sprintf("translation address %s", p.nicIp),
+				)
+				updated = true
+			}
+		}
+		if updated {
+			tree.Apply(false)
 		}
 	}
 

--- a/plugin/snat_test.go
+++ b/plugin/snat_test.go
@@ -179,7 +179,7 @@ func checkSnatRuleSet(pub, pri utils.NicInfo) {
 	tree := server.NewParserFromShowConfiguration().Tree
 
 	priNicNum, _ := utils.GetNicNumber(pri.Name)
-	pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumber(priNicNum)
+	pubNicRuleNo, priNicRuleNo := utils.GetPublicNicSNATRuleNumber(priNicNum)
 	cidr, _ := utils.GetNetworkNumber(pri.Ip, pri.Netmask)
 
 	cmd := fmt.Sprintf("nat source rule %d outbound-interface %s", pubNicRuleNo, pub.Name)
@@ -210,7 +210,7 @@ func checkSnatRuleSet(pub, pri utils.NicInfo) {
 func checkSnatRuleDel(pri utils.NicInfo) {
 	tree := server.NewParserFromShowConfiguration().Tree
 	priNicNum, _ := utils.GetNicNumber(pri.Name)
-	pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumber(priNicNum)
+	pubNicRuleNo, priNicRuleNo := utils.GetPublicNicSNATRuleNumber(priNicNum)
 
 	rule := tree.Get(fmt.Sprintf("nat source rule %d", pubNicRuleNo))
 	gomega.Expect(rule).To(gomega.BeNil(), "snat rule [%d] delete failed", pubNicRuleNo)
@@ -221,7 +221,7 @@ func checkSnatRuleDel(pri utils.NicInfo) {
 
 func checkSnatVyosIpTables(pub, pri utils.NicInfo, add bool) {
 	priNicNum, _ := utils.GetNicNumber(pri.Name)
-	pubNicRuleNo, priNicRuleNo := getNicSNATRuleNumber(priNicNum)
+	pubNicRuleNo, priNicRuleNo := utils.GetPublicNicSNATRuleNumber(priNicNum)
 	cidr, _ := utils.GetNetworkNumber(pri.Ip, pri.Netmask)
 
 	cmd := fmt.Sprintf("iptables -t nat -C POSTROUTING -s %s ! -d 224.0.0.0/8 -o %s -m comment --comment SRC-NAT-%d -j SNAT --to-source %s",

--- a/utils/ip_constants.go
+++ b/utils/ip_constants.go
@@ -35,7 +35,7 @@ const (
 	RT_TABLES_LOCAL   = 255
 	RT_TABLES_MAIN    = 254
 	RT_TABLES_DEFAULT = 253
-	RT_TABLES_MGMT = 250
+	RT_TABLES_MGMT    = 250
 	RT_TABLES_UNSPEC  = 0
 )
 
@@ -63,3 +63,18 @@ const (
 	IF_OPER_DORMANT        = 0x5
 	IF_OPER_UP             = 0x6
 )
+
+const (
+	PRIVATE_SNAT_RULE_NUMBER = 9799
+	SNAT_RULE_NUMBER         = 9999
+)
+
+func GetPublicNicSNATRuleNumber(nicNo int) (pubNicRuleNo int, priNicRuleNo int) {
+	pubNicRuleNo = SNAT_RULE_NUMBER - nicNo*2
+	priNicRuleNo = pubNicRuleNo - 1
+	return
+}
+
+func GetPrivateNicSNATRuleNumber(nicNo int) (priNicRuleNo int) {
+	return PRIVATE_SNAT_RULE_NUMBER - nicNo
+}

--- a/utils/iptables.go
+++ b/utils/iptables.go
@@ -569,10 +569,10 @@ func InitIptablesFlags() {
 	}
 }
 
-func AddSnatRuleForPrivateNic(nicName, ip, netmask string) {
+func AddSnatRuleForPrivateNic(nicName, ip, netmask string) (err error) {
 	if ip == "" || strings.Contains(ip, ":") {
 		/* TODO: add ipv6 support */
-		return
+		return fmt.Errorf("ipv6 is not supported")
 	}
 	table := NewIpTables(NatTable)
 	address, err := GetNetworkNumber(ip, netmask)
@@ -583,13 +583,13 @@ func AddSnatRuleForPrivateNic(nicName, ip, netmask string) {
 	rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetSrcIpRange(fmt.Sprintf("! %s-%s", ip, ip)).
 		SetOutNic(nicName).SetSnatTargetIp(ip)
 	table.AddIpTableRules([]*IpTableRule{rule})
-	table.Apply()
+	return table.Apply()
 }
 
-func RemoveSnatRuleForPrivateNic(nicName, ip, netmask string) {
+func RemoveSnatRuleForPrivateNic(nicName, ip, netmask string) error {
 	if ip == "" || strings.Contains(ip, ":") {
 		/* TODO: add ipv6 support */
-		return
+		return nil
 	}
 
 	table := NewIpTables(NatTable)
@@ -601,5 +601,5 @@ func RemoveSnatRuleForPrivateNic(nicName, ip, netmask string) {
 	rule.SetDstIp("! 224.0.0.0/8").SetSrcIp(address).SetSrcIpRange(fmt.Sprintf("! %s-%s", ip, ip)).
 		SetOutNic(nicName).SetSnatTargetIp(ip)
 	table.RemoveIpTableRule([]*IpTableRule{rule})
-	table.Apply()
+	return table.Apply()
 }

--- a/utils/vyosIptables.go
+++ b/utils/vyosIptables.go
@@ -85,10 +85,11 @@ var filterOutRulesPriority = map[string]int{
 }
 
 var snatRulesPriority = map[string]int{
-	SystemTopRule:    1,
-	IpsecRuleComment: 1000,
-	EipRuleComment:   2000,
-	SNATComment:      IPTABLES_RULENUMBER_MAX,
+	SystemTopRule:         1,
+	IpsecRuleComment:      1000,
+	EipRuleComment:        2000,
+	PrivateNicSNATComment: 6000,
+	SNATComment:           IPTABLES_RULENUMBER_MAX,
 }
 
 var dnatRulesPriority = map[string]int{

--- a/zvrboot/zvrboot.go
+++ b/zvrboot/zvrboot.go
@@ -492,6 +492,8 @@ func configureVyos() {
 			}
 			if nic.category == "Private" {
 				err = utils.InitNicFirewall(nic.name, nic.ip, false, utils.IPTABLES_ACTION_REJECT)
+				// add private SNAT rule in iptables
+				err = utils.AddSnatRuleForPrivateNic(nic.name, nic.ip, nic.netmask)
 			} else {
 				err = utils.InitNicFirewall(nic.name, nic.ip, true, utils.IPTABLES_ACTION_REJECT)
 			}
@@ -552,6 +554,19 @@ func configureVyos() {
 
 			setNicTree.AttachFirewallToInterface(nic.name, "local")
 			setNicTree.AttachFirewallToInterface(nic.name, "in")
+
+			if nic.category == "Private" {
+				// add private SNAT rule in VyOS config tree
+				nicNo, _ := utils.GetNicNumber(nic.name)
+				ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
+				address, _ := utils.GetNetworkNumber(nic.ip, nic.netmask)
+				setNicTree.SetSnatWithRuleNumber(ruleNo,
+					fmt.Sprintf("outbound-interface %s", nic.name),
+					fmt.Sprintf("source address %s", address),
+					"destination address !224.0.0.0/8",
+					fmt.Sprintf("translation address %s", nic.ip),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves: ZSTAC-12345

Change-Id: I6b796e75787a617662717a69746d62646f6e6363

sync from gitlab !1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为私有网络接口添加了 SNAT 规则的自动管理与同步，Linux 与 VyOS 路径均支持。

* **错误处理改进**
  * 增强了在配置与移除防火墙/规则时的错误传播与处理，减少残留或半配置状态。

* **优化调整**
  * 将私有 SNAT 规则与网卡生命周期对齐，自动创建/删除并在同步时补齐缺失规则，避免重复规则。

* **维护**
  * 新增公共工具以统一计算和管理 SNAT 规则编号与存在性检查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->