### PR TITLE
Merge branch 'shixin-ZSTAC-81286' into '5.5.6'

### DIFF
--- a/plugin/auxiliary.go
+++ b/plugin/auxiliary.go
@@ -503,6 +503,13 @@ func SetZebraRoutes(infos []RouteInfo) {
 		err       error
 	)
 
+	changeDefaultRoute := false
+	for _, info := range infos {
+		if info.Destination == "0.0.0.0/0" {
+			changeDefaultRoute = true
+		}
+	}
+
 	// 1. get old routes by load json
 	if utils.IsEuler2203() {
 		routes := utils.GetCurrentRouteEntriesEuler2203(utils.ROUTETABLE_ID_MAIN)
@@ -543,6 +550,11 @@ func SetZebraRoutes(infos []RouteInfo) {
 		}
 
 		if !found {
+			if old.Dst == "0.0.0.0/0" && !changeDefaultRoute {
+				// mn don't want to change default
+				continue
+			}
+
 			if old.NextHop == "" {
 				old.NextHop = "Null0"
 			}


### PR DESCRIPTION
<fix>[auxiliary]: don't delete default route of euler router

See merge request zstackio/zstack-vyos!1054

(cherry picked from commit 713570cfc222b78b68de458b59305e9b78038f48)

81f7771f <fix>[auxiliary]: don't delete default route of euler router

sync from gitlab !1057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了网络路由管理逻辑，增强了对默认路由的保护机制。在处理网络配置时，默认路由现在仅在明确请求修改时才会被改动。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->