### PR TITLE
<fix>[lb]: remove vip counter log

### DIFF
--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -127,7 +127,7 @@ type RedirectRuleInfo struct {
 	AclUuid          string `json:"aclUuid"`
 	RedirectRule     string `json:"redirectRule"`
 	ServerGroupUuid  string `json:"serverGroupUuid"`
-	RedirectPort	 int    `json:"redirectPort"`
+	RedirectPort     int    `json:"redirectPort"`
 }
 
 type LbInfo struct {
@@ -164,9 +164,9 @@ type deleteCertificateCmd struct {
 
 /* RedirectServerGroup just for redirect acl rules */
 type RedirectServerGroup struct {
-	InternalName   string
+	InternalName    string
 	ServerGroupUuid string
-	RedirectPort int
+	RedirectPort    int
 	BackendServers  []BackendServerInfo
 }
 
@@ -1463,6 +1463,36 @@ func makeLbFirewallLocalICMPRuleDescription(lb LbInfo) string {
 	return fmt.Sprintf("LBICMP-%v", lb.LbUuid)
 }
 
+func hasIcmpAcceptRuleOnVyos(tree *server.VyosConfigTree, nicname, vip string) bool {
+	rs := tree.Getf("firewall name %v.local rule", nicname)
+	if rs == nil {
+		return false
+	}
+
+	for _, r := range rs.Children() {
+		proto := r.Get("protocol")
+		dst := r.Get("destination address")
+		action := r.Get("action")
+		if proto != nil && proto.Value() == "icmp" &&
+			dst != nil && dst.Value() == vip &&
+			action != nil && action.Value() == "accept" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasIcmpRuleOnIptables(table *utils.IpTables, rule *utils.IpTableRule) bool {
+	if table.Check(rule) {
+		return true
+	}
+
+	vipIcmpRule := rule.Copy()
+	vipIcmpRule.SetAction(utils.IPTABLES_ACTION_ACCEPT)
+	return table.Check(vipIcmpRule)
+}
+
 func setLb(lb LbInfo) bool {
 	listener := GetListener(lb)
 	if listener == nil {
@@ -1708,6 +1738,26 @@ func addRuleForTcpListenerByVyos(lbs []Listener) error {
 			"action accept",
 		)
 
+		localICMPDes := makeLbFirewallLocalICMPRuleDescription(info)
+		if !hasIcmpAcceptRuleOnVyos(tree, nicname, info.Vip) && tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes) == nil {
+			tree.SetFirewallOnInterface(nicname, "local",
+				fmt.Sprintf("description %v", localICMPDes),
+				fmt.Sprintf("destination address %v", info.Vip),
+				"protocol icmp",
+				"action accept",
+			)
+		}
+		for _, priNic := range utils.GetPrivteInterface() {
+			if !hasIcmpAcceptRuleOnVyos(tree, priNic, info.Vip) && tree.FindFirewallRuleByDescription(priNic, "local", localICMPDes) == nil {
+				tree.SetFirewallOnInterface(priNic, "local",
+					fmt.Sprintf("description %v", localICMPDes),
+					fmt.Sprintf("destination address %v", info.Vip),
+					"protocol icmp",
+					"action accept",
+				)
+			}
+		}
+
 		tree.AttachFirewallToInterface(nicname, "local")
 	}
 
@@ -1746,6 +1796,22 @@ func addRuleForTcpListenerByLinux(lbs []Listener) error {
 			}
 		}
 
+		icmpRules, _ := lb.getIcmpIptablesRule()
+		for _, r := range icmpRules {
+			if !hasIcmpRuleOnIptables(table, r) {
+				table.AddIpTableRules([]*utils.IpTableRule{r})
+			}
+		}
+
+		for _, priNic := range priNics {
+			for _, r := range icmpRules {
+				newRule := r.Copy()
+				newRule.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
+				if !hasIcmpRuleOnIptables(table, newRule) {
+					table.AddIpTableRules([]*utils.IpTableRule{newRule})
+				}
+			}
+		}
 	}
 
 	if changed {
@@ -1794,6 +1860,26 @@ func addRuleForUdpListenerByVyos(lbs []Listener) error {
 			"action accept",
 		)
 
+		localICMPDes := makeLbFirewallLocalICMPRuleDescription(info)
+		if !hasIcmpAcceptRuleOnVyos(tree, nicname, info.Vip) && tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes) == nil {
+			tree.SetFirewallOnInterface(nicname, "local",
+				fmt.Sprintf("description %v", localICMPDes),
+				fmt.Sprintf("destination address %v", info.Vip),
+				"protocol icmp",
+				"action accept",
+			)
+		}
+		for _, priNic := range utils.GetPrivteInterface() {
+			if !hasIcmpAcceptRuleOnVyos(tree, priNic, info.Vip) && tree.FindFirewallRuleByDescription(priNic, "local", localICMPDes) == nil {
+				tree.SetFirewallOnInterface(priNic, "local",
+					fmt.Sprintf("description %v", localICMPDes),
+					fmt.Sprintf("destination address %v", info.Vip),
+					"protocol icmp",
+					"action accept",
+				)
+			}
+		}
+
 		tree.AttachFirewallToInterface(nicname, "local")
 	}
 
@@ -1831,6 +1917,23 @@ func addRuleForUdpListenerByLinux(lbs []Listener) error {
 				table.AddIpTableRules([]*utils.IpTableRule{newRule})
 			}
 		}
+
+		icmpRules, _ := lb.getIcmpIptablesRule()
+		for _, r := range icmpRules {
+			if !hasIcmpRuleOnIptables(table, r) {
+				table.AddIpTableRules([]*utils.IpTableRule{r})
+			}
+		}
+
+		for _, priNic := range priNics {
+			for _, r := range icmpRules {
+				newRule := r.Copy()
+				newRule.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
+				if !hasIcmpRuleOnIptables(table, newRule) {
+					table.AddIpTableRules([]*utils.IpTableRule{newRule})
+				}
+			}
+		}
 	}
 
 	if changed {
@@ -1841,6 +1944,10 @@ func addRuleForUdpListenerByLinux(lbs []Listener) error {
 
 func delRuleForTcpListenerByVyos(lbs []Listener) error {
 	tree := server.NewParserFromShowConfiguration().Tree
+	excludeSet := make(map[string]struct{}, len(lbs))
+	for _, lb := range lbs {
+		excludeSet[lb.getLbInfo().ListenerUuid] = struct{}{}
+	}
 
 	changed := false
 	for _, lb := range lbs {
@@ -1857,10 +1964,13 @@ func delRuleForTcpListenerByVyos(lbs []Listener) error {
 		if r := tree.FindFirewallRuleByDescription(nicname, "local", des); r != nil {
 			r.Delete()
 		}
-		if r := tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes); (r != nil) && (getListenerCountInLB(info) == 0) {
+		if r := tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes); (r != nil) && (getListenerCountInLB(info, excludeSet) == 0) {
 			r.Delete()
 		}
 		cleanInternalFirewallRule(tree, des)
+		if getListenerCountInLB(info, excludeSet) == 0 {
+			cleanInternalFirewallRule(tree, localICMPDes)
+		}
 	}
 
 	if changed {
@@ -1872,6 +1982,10 @@ func delRuleForTcpListenerByVyos(lbs []Listener) error {
 
 func delRuleForTcpListenerByLinux(lbs []Listener) error {
 	table := utils.NewIpTables(utils.FirewallTable)
+	excludeSet := make(map[string]struct{}, len(lbs))
+	for _, lb := range lbs {
+		excludeSet[lb.getLbInfo().ListenerUuid] = struct{}{}
+	}
 
 	changed := false
 	for _, lb := range lbs {
@@ -1886,43 +2000,51 @@ func delRuleForTcpListenerByLinux(lbs []Listener) error {
 		}
 
 		changed = true
-		var rules []*utils.IpTableRule
 		nicname, err := utils.GetNicNameByMac(info.PublicNic)
 		utils.PanicOnError(err)
 
-		r, _ := lb.getIptablesRule()
-		rules = append(rules, r...)
+		rules, _ := lb.getIptablesRule()
+		table.RemoveIpTableRule(rules)
 
-		rules, _ = lb.getIcmpIptablesRule()
-		rules = append(rules, r...)
-
-		var tempRules []*utils.IpTableRule
 		priNics := utils.GetPrivteInterface()
 		for _, priNic := range priNics {
 			if priNic != nicname {
 				for _, r := range rules {
 					tmp := r.Copy()
 					tmp.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
-					tempRules = append(tempRules, tmp)
+					table.RemoveIpTableRule([]*utils.IpTableRule{tmp})
 				}
 			}
 		}
-		if len(tempRules) > 0 {
-			rules = append(rules, tempRules...)
-		}
 
-		table.RemoveIpTableRule(rules)
+		if getListenerCountInLB(info, excludeSet) == 0 {
+			icmpRules, _ := lb.getIcmpIptablesRule()
+			table.RemoveIpTableRule(icmpRules)
+
+			for _, priNic := range priNics {
+				if priNic != nicname {
+					for _, r := range icmpRules {
+						tmp := r.Copy()
+						tmp.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
+						table.RemoveIpTableRule([]*utils.IpTableRule{tmp})
+					}
+				}
+			}
+		}
 	}
 
 	if changed {
 		return table.Apply()
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func delRuleForUdpListenerByVyos(lbs []Listener) error {
 	tree := server.NewParserFromShowConfiguration().Tree
+	excludeSet := make(map[string]struct{}, len(lbs))
+	for _, lb := range lbs {
+		excludeSet[lb.getLbInfo().ListenerUuid] = struct{}{}
+	}
 
 	changed := false
 	for _, lb := range lbs {
@@ -1943,10 +2065,13 @@ func delRuleForUdpListenerByVyos(lbs []Listener) error {
 			r.Delete()
 			r = tree.FindFirewallRuleByDescription(nicname, "local", firewallDes)
 		}
-		if r := tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes); (r != nil) && (getListenerCountInLB(info) == 0) {
+		if r := tree.FindFirewallRuleByDescription(nicname, "local", localICMPDes); (r != nil) && (getListenerCountInLB(info, excludeSet) == 0) {
 			r.Delete()
 		}
 		cleanInternalFirewallRule(tree, firewallDes)
+		if getListenerCountInLB(info, excludeSet) == 0 {
+			cleanInternalFirewallRule(tree, localICMPDes)
+		}
 	}
 
 	if changed {
@@ -1958,6 +2083,10 @@ func delRuleForUdpListenerByVyos(lbs []Listener) error {
 
 func delRuleForUdpListenerByLinux(lbs []Listener) error {
 	table := utils.NewIpTables(utils.FirewallTable)
+	excludeSet := make(map[string]struct{}, len(lbs))
+	for _, lb := range lbs {
+		excludeSet[lb.getLbInfo().ListenerUuid] = struct{}{}
+	}
 
 	changed := false
 	for _, lb := range lbs {
@@ -1972,20 +2101,37 @@ func delRuleForUdpListenerByLinux(lbs []Listener) error {
 		}
 
 		changed = true
+		nicname, err := utils.GetNicNameByMac(info.PublicNic)
+		utils.PanicOnError(err)
+
 		rules, _ := lb.getIptablesRule()
 		table.RemoveIpTableRule(rules)
 
 		priNics := utils.GetPrivteInterface()
 		for _, priNic := range priNics {
-			for _, r := range rules {
-				newRule := r.Copy()
-				newRule.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
-				table.RemoveIpTableRule([]*utils.IpTableRule{newRule})
+			if priNic != nicname {
+				for _, r := range rules {
+					newRule := r.Copy()
+					newRule.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
+					table.RemoveIpTableRule([]*utils.IpTableRule{newRule})
+				}
 			}
 		}
 
-		rules, _ = lb.getIcmpIptablesRule()
-		table.RemoveIpTableRule(rules)
+		if getListenerCountInLB(info, excludeSet) == 0 {
+			icmpRules, _ := lb.getIcmpIptablesRule()
+			table.RemoveIpTableRule(icmpRules)
+
+			for _, priNic := range priNics {
+				if priNic != nicname {
+					for _, r := range icmpRules {
+						newRule := r.Copy()
+						newRule.SetChainName(utils.GetRuleSetName(priNic, utils.RULESET_LOCAL))
+						table.RemoveIpTableRule([]*utils.IpTableRule{newRule})
+					}
+				}
+			}
+		}
 	}
 
 	if changed {
@@ -2557,25 +2703,30 @@ var goBetweenClient = &http.Client{
 	Timeout: time.Second * 5,
 }
 
-func getListenerCountInLB(lb LbInfo) (counter int) {
+// getListenerCountInLB counts listeners sharing the same LbUuid,
+// excluding listeners whose ListenerUuid is in excludeSet.
+// Pass an excludeSet containing the UUIDs of listeners being deleted,
+// so the count reflects the post-deletion state even before LbListeners
+// has been updated.
+func getListenerCountInLB(lb LbInfo, excludeSet map[string]struct{}) (counter int) {
 	counter = 0
 	for _, listener := range LbListeners {
 		var lbtmp LbInfo
 		switch v := listener.(type) {
 		case *HaproxyListener:
 			lbtmp = v.getLbInfo()
-			break
 		case *GBListener:
 			lbtmp = v.getLbInfo()
-			break
 		default:
 			continue
 		}
 		if lb.LbUuid == lbtmp.LbUuid {
-			counter++
+			if _, excluded := excludeSet[lbtmp.ListenerUuid]; !excluded {
+				counter++
+			}
 		}
 	}
-	log.Debugf("lb-%s contains %d listener", lb.LbUuid, counter)
+	log.Debugf("lb-%s contains %d listener (excluding %d)", lb.LbUuid, counter, len(excludeSet))
 	return
 }
 

--- a/plugin/vip.go
+++ b/plugin/vip.go
@@ -1765,10 +1765,39 @@ type SessionStat struct {
 
 func (s *SessionStat) Key() string {
 	if s.Protocol == "icmp" {
-		return fmt.Sprintf("%s-%s-%s-%s-%s", s.Protocol, s.SrcIp, s.DstIp, s.IcmpType, s.IcmpCode)
-	} else {
-		return fmt.Sprintf("%s-%s-%s-%s-%s", s.Protocol, s.SrcIp, s.SrcPort, s.DstIp, s.DstPort)
+		return s.Protocol + "-" + s.SrcIp + "-" + s.DstIp + "-" + s.IcmpType + "-" + s.IcmpCode
 	}
+	return s.Protocol + "-" + s.SrcIp + "-" + s.SrcPort + "-" + s.DstIp + "-" + s.DstPort
+}
+
+// extractDstIps extracts the two dst= IP addresses from a conntrack line.
+// A conntrack line contains two tuples: the original direction and the reply direction.
+// Example: ipv4 2 tcp 6 86390 ESTABLISHED src=10.0.0.1 dst=192.168.1.100 sport=12345 dport=80 packets=10 bytes=600 src=192.168.1.100 dst=10.0.0.1 sport=80 dport=12345 packets=8 bytes=480 mark=0 zone=0 use=2
+// Returns (original-dst, reply-dst), i.e. ("192.168.1.100", "10.0.0.1") in the example above.
+func extractDstIps(line string) (string, string) {
+	var first, second string
+	searchFrom := 0
+	for i := 0; i < 2; i++ {
+		idx := strings.Index(line[searchFrom:], "dst=")
+		if idx < 0 {
+			break
+		}
+
+		start := searchFrom + idx + 4
+		end := start
+		for end < len(line) && line[end] != ' ' && line[end] != '\t' {
+			end++
+		}
+
+		if i == 0 {
+			first = line[start:end]
+		} else {
+			second = line[start:end]
+		}
+		searchFrom = end
+	}
+
+	return first, second
 }
 
 // parseConntrackLine parses a single line from /proc/net/nf_conntrack.
@@ -1876,6 +1905,9 @@ func (c *vipCollector) updateCountersByConntrack() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	startTime := time.Now()
+	var totalSessions, parsedSessions, skippedSessions, newSessions, staleSessions, matchedSessions int
+
 	file, err := os.Open("/proc/net/nf_conntrack")
 	if err != nil {
 		log.Warnf("Failed to open /proc/net/nf_conntrack: %v", err)
@@ -1888,11 +1920,21 @@ func (c *vipCollector) updateCountersByConntrack() {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		stat, ok := parseConntrackLine(line)
-		if !ok {
-			log.Debugf("failed to parse conntrack line: %s", line)
+		totalSessions++
+
+		firstDst, secondDst := extractDstIps(line)
+		_, matchFirst := c.counters[firstDst]
+		_, matchSecond := c.counters[secondDst]
+		if !matchFirst && !matchSecond {
+			skippedSessions++
 			continue
 		}
+
+		stat, ok := parseConntrackLine(line)
+		if !ok {
+			continue
+		}
+		parsedSessions++
 		stat.LastUpdate = currentTime
 		currentStats[stat.Key()] = stat
 	}
@@ -1903,6 +1945,9 @@ func (c *vipCollector) updateCountersByConntrack() {
 
 	for key, current := range currentStats {
 		previous, exists := c.previousStats[key]
+		if !exists {
+			newSessions++
+		}
 
 		var pktIn, bytesIn, pktOut, bytesOut uint64
 
@@ -1921,15 +1966,13 @@ func (c *vipCollector) updateCountersByConntrack() {
 		}
 
 		if counter, ok := c.counters[current.DstIp]; ok {
-			log.Debugf("update incoming counter, vip: %s:%s, pktIn: %d, bytesIn: %d, pktOut: %d, bytesOut: %d",
-				counter.VipUuid, current.DstIp, pktIn, bytesIn, pktOut, bytesOut)
+			matchedSessions++
 			counter.InPackets += pktIn
 			counter.InBytes += bytesIn
 			counter.OutPackets += pktOut
 			counter.OutBytes += bytesOut
 		} else if counter, ok := c.counters[current.ReplyDstIp]; ok {
-			log.Debugf("update out counter, vip: %s:%s, pktIn: %d, bytesIn: %d, pktOut: %d, bytesOut: %d",
-				counter.VipUuid, current.ReplyDstIp, pktIn, bytesIn, pktOut, bytesOut)
+			matchedSessions++
 			counter.OutPackets += pktIn
 			counter.OutBytes += bytesIn
 			counter.InPackets += pktOut
@@ -1943,10 +1986,13 @@ func (c *vipCollector) updateCountersByConntrack() {
 	// Clean up sessions older than 300 seconds from previousStats
 	for key, previous := range c.previousStats {
 		if currentTime-previous.LastUpdate > 300 {
-			log.Debugf("Removing stale session from previousStats: %s, age: %d seconds", key, currentTime-previous.LastUpdate)
+			staleSessions++
 			delete(c.previousStats, key)
 		}
 	}
+
+	log.Debugf("updateCountersByConntrack completed: duration=%v, totalSessions=%d, skippedSessions=%d, parsedSessions=%d, newSessions=%d, matchedSessions=%d, staleSessions=%d",
+		time.Since(startTime), totalSessions, skippedSessions, parsedSessions, newSessions, matchedSessions, staleSessions)
 }
 
 func (c *vipCollector) Update(ch chan<- prom.Metric) error {


### PR DESCRIPTION
Resolves: ZSTAC-83769

Change-Id: I78747164746b6b6d706b72686673747973726577

sync from gitlab !1079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为负载均衡器扩展 ICMP 支持：在添加 TCP/UDP 监听时，自动在公网和各私有接口上确保存在 ICMP 允许规则（适用于 VyOS 和 Linux 环境）。

* **改进**
  * 优化删除行为：仅在排除正在删除的监听器后且无剩余监听器时才移除 ICMP 规则，避免误删。
  * Linux 环境的规则移除改为逐项删除以提升准确性。
  * 连接跟踪统计改为聚合汇总并减少逐条调试日志，日志更简洁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->