### PR TITLE
<fix>[vip]: fix vipCollector self-deadlock on conntrack path

### DIFF
--- a/plugin/vip.go
+++ b/plugin/vip.go
@@ -1968,10 +1968,13 @@ func parseConntrackLine(line string) (*SessionStat, bool) {
 	return stat, true
 }
 
+// updateCountersByConntrack assumes the caller already holds c.mu.
+// Its only caller, Update(), locks c.mu before dispatching to the eBPF
+// or conntrack path; locking again here would self-deadlock since
+// sync.Mutex is non-reentrant, leaving c.mu held forever. Subsequent
+// SetVip / RemoveVip handlers block on vipPromCollector.mu.Lock() and
+// async commands never invoke their callback URL.
 func (c *vipCollector) updateCountersByConntrack() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	startTime := time.Now()
 	var totalSessions, parsedSessions, skippedSessions, newSessions, staleSessions, matchedSessions int
 


### PR DESCRIPTION
Update() locks c.mu and dispatches to updateCountersByConntrack(), which
also calls c.mu.Lock() at entry. sync.Mutex is non-reentrant, so the
second Lock blocks forever AND c.mu is never released — every later
SetVip/RemoveVip handler that takes vipPromCollector.mu.Lock() hangs,
causing async commands (e.g. /createvip) to ack 200 but never invoke the
callback URL.

Triggered on non-OpenEuler-22.03 platforms where ebpfObjs == nil and the
collector falls back to the conntrack path; first /metrics scrape after
zvr start is enough to hang the process.

Drop the redundant Lock/Unlock inside updateCountersByConntrack — the
sole caller (Update) already holds c.mu, and document the contract.

Resolves: ZSTAC-83769

Change-Id: I124c40c827eb7f0717a8de8baf9481aabdb0344e

sync from gitlab !1089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了 VIP 计数器的更新流程，提升了性能与稳定性。
  * 简化并发锁处理，降低自锁/死锁风险并改善下游阻塞行为的可预测性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->