### PR TITLE
<fix>[vip]: avoid createvip blocked by metrics

### DIFF
--- a/plugin/vip.go
+++ b/plugin/vip.go
@@ -5,12 +5,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -1501,9 +1503,11 @@ func RemoveVip(cmd *removeVipCmd) interface{} {
 			vipPromCollector.mu.Lock()
 			if vip.Ip != "" {
 				delete(vipPromCollector.counters, vip.Ip)
+				vipPromCollector.removePreviousStatsByVip(vip.Ip)
 			}
 			if vip.Ip6 != "" {
 				delete(vipPromCollector.counters, vip.Ip6)
+				vipPromCollector.removePreviousStatsByVip(vip.Ip6)
 			}
 			vipPromCollector.mu.Unlock()
 		}
@@ -1752,15 +1756,19 @@ type vipCollector struct {
 	outPktEntry  *prom.Desc
 
 	// Fields for conntrack-based monitoring
-	mu            sync.Mutex
-	previousStats map[string]*SessionStat
-	counters      map[string]*VipCounter
+	mu                       sync.Mutex
+	previousStats            map[string]*SessionStat
+	counters                 map[string]*VipCounter
+	conntrackCollecting      atomic.Bool
+	lastConntrackCollectNano atomic.Int64
 }
 
 var vipPromCollector *vipCollector
 
 const (
-	LABEL_VIP_UUID = "VipUUID"
+	LABEL_VIP_UUID             = "VipUUID"
+	conntrackCollectInterval   = 15 * time.Second
+	conntrackSessionStaleAfter = 300
 )
 
 func NewVipPrometheusCollector() MetricCollector {
@@ -1968,15 +1976,69 @@ func parseConntrackLine(line string) (*SessionStat, bool) {
 	return stat, true
 }
 
-// updateCountersByConntrack assumes the caller already holds c.mu.
-// Its only caller, Update(), locks c.mu before dispatching to the eBPF
-// or conntrack path; locking again here would self-deadlock since
-// sync.Mutex is non-reentrant, leaving c.mu held forever. Subsequent
-// SetVip / RemoveVip handlers block on vipPromCollector.mu.Lock() and
-// async commands never invoke their callback URL.
+type conntrackCollectStats struct {
+	totalSessions   int
+	parsedSessions  int
+	skippedSessions int
+	newSessions     int
+	staleSessions   int
+	matchedSessions int
+}
+
+func (c *vipCollector) snapshotVipCounters() []VipCounter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	counters := make([]VipCounter, 0, len(c.counters))
+	for _, counter := range c.counters {
+		if counter == nil {
+			continue
+		}
+		counters = append(counters, *counter)
+	}
+	return counters
+}
+
+func (c *vipCollector) snapshotConntrackVips() map[string]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	vips := make(map[string]string, len(c.counters))
+	for vip, counter := range c.counters {
+		if counter == nil {
+			continue
+		}
+		vips[vip] = counter.VipUuid
+	}
+	return vips
+}
+
+func (c *vipCollector) maybeStartConntrackCollect() {
+	now := time.Now()
+	if last := c.lastConntrackCollectNano.Load(); last > 0 && now.Sub(time.Unix(0, last)) < conntrackCollectInterval {
+		return
+	}
+
+	if !c.conntrackCollecting.CompareAndSwap(false, true) {
+		return
+	}
+	c.lastConntrackCollectNano.Store(now.UnixNano())
+
+	go func() {
+		defer c.conntrackCollecting.Store(false)
+		c.updateCountersByConntrack()
+	}()
+}
+
+// updateCountersByConntrack runs outside the Prometheus request path. It only
+// takes c.mu to copy the VIP set and later merge deltas, so SetVip/RemoveVip
+// cannot be blocked by a full /proc/net/nf_conntrack scan.
 func (c *vipCollector) updateCountersByConntrack() {
 	startTime := time.Now()
-	var totalSessions, parsedSessions, skippedSessions, newSessions, staleSessions, matchedSessions int
+	vips := c.snapshotConntrackVips()
+	if len(vips) == 0 {
+		return
+	}
 
 	file, err := os.Open("/proc/net/nf_conntrack")
 	if err != nil {
@@ -1985,18 +2047,27 @@ func (c *vipCollector) updateCountersByConntrack() {
 	}
 	defer file.Close()
 
+	deltas, stats := c.collectConntrackCounters(file, vips, time.Now().Unix())
+	c.applyConntrackDeltas(deltas)
+
+	log.Debugf("updateCountersByConntrack completed: duration=%v, totalSessions=%d, skippedSessions=%d, parsedSessions=%d, newSessions=%d, matchedSessions=%d, staleSessions=%d",
+		time.Since(startTime), stats.totalSessions, stats.skippedSessions, stats.parsedSessions, stats.newSessions, stats.matchedSessions, stats.staleSessions)
+}
+
+func (c *vipCollector) collectConntrackCounters(reader io.Reader, vips map[string]string, currentTime int64) (map[string]*VipCounter, conntrackCollectStats) {
+	var stats conntrackCollectStats
+	deltas := make(map[string]*VipCounter)
 	currentStats := make(map[string]*SessionStat)
-	currentTime := time.Now().Unix()
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
-		totalSessions++
+		stats.totalSessions++
 
 		firstDst, secondDst := extractDstIps(line)
-		_, matchFirst := c.counters[firstDst]
-		_, matchSecond := c.counters[secondDst]
+		_, matchFirst := vips[firstDst]
+		_, matchSecond := vips[secondDst]
 		if !matchFirst && !matchSecond {
-			skippedSessions++
+			stats.skippedSessions++
 			continue
 		}
 
@@ -2004,7 +2075,7 @@ func (c *vipCollector) updateCountersByConntrack() {
 		if !ok {
 			continue
 		}
-		parsedSessions++
+		stats.parsedSessions++
 		stat.LastUpdate = currentTime
 		currentStats[stat.Key()] = stat
 	}
@@ -2016,7 +2087,7 @@ func (c *vipCollector) updateCountersByConntrack() {
 	for key, current := range currentStats {
 		previous, exists := c.previousStats[key]
 		if !exists {
-			newSessions++
+			stats.newSessions++
 		}
 
 		var pktIn, bytesIn, pktOut, bytesOut uint64
@@ -2035,14 +2106,24 @@ func (c *vipCollector) updateCountersByConntrack() {
 			bytesOut = current.ReplyBytes
 		}
 
-		if counter, ok := c.counters[current.DstIp]; ok {
-			matchedSessions++
+		if vipUuid, ok := vips[current.DstIp]; ok {
+			stats.matchedSessions++
+			counter := deltas[current.DstIp]
+			if counter == nil {
+				counter = &VipCounter{VipUuid: vipUuid}
+				deltas[current.DstIp] = counter
+			}
 			counter.InPackets += pktIn
 			counter.InBytes += bytesIn
 			counter.OutPackets += pktOut
 			counter.OutBytes += bytesOut
-		} else if counter, ok := c.counters[current.ReplyDstIp]; ok {
-			matchedSessions++
+		} else if vipUuid, ok := vips[current.ReplyDstIp]; ok {
+			stats.matchedSessions++
+			counter := deltas[current.ReplyDstIp]
+			if counter == nil {
+				counter = &VipCounter{VipUuid: vipUuid}
+				deltas[current.ReplyDstIp] = counter
+			}
 			counter.OutPackets += pktIn
 			counter.OutBytes += bytesIn
 			counter.InPackets += pktOut
@@ -2055,14 +2136,42 @@ func (c *vipCollector) updateCountersByConntrack() {
 
 	// Clean up sessions older than 300 seconds from previousStats
 	for key, previous := range c.previousStats {
-		if currentTime-previous.LastUpdate > 300 {
-			staleSessions++
+		if currentTime-previous.LastUpdate > conntrackSessionStaleAfter {
+			stats.staleSessions++
 			delete(c.previousStats, key)
 		}
 	}
 
-	log.Debugf("updateCountersByConntrack completed: duration=%v, totalSessions=%d, skippedSessions=%d, parsedSessions=%d, newSessions=%d, matchedSessions=%d, staleSessions=%d",
-		time.Since(startTime), totalSessions, skippedSessions, parsedSessions, newSessions, matchedSessions, staleSessions)
+	return deltas, stats
+}
+
+func (c *vipCollector) applyConntrackDeltas(deltas map[string]*VipCounter) {
+	if len(deltas) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for vip, delta := range deltas {
+		counter, ok := c.counters[vip]
+		if !ok || counter == nil {
+			continue
+		}
+
+		counter.InPackets += delta.InPackets
+		counter.InBytes += delta.InBytes
+		counter.OutPackets += delta.OutPackets
+		counter.OutBytes += delta.OutBytes
+	}
+}
+
+func (c *vipCollector) removePreviousStatsByVip(vip string) {
+	for key, stat := range c.previousStats {
+		if stat.DstIp == vip || stat.ReplyDstIp == vip {
+			delete(c.previousStats, key)
+		}
+	}
 }
 
 func (c *vipCollector) Update(ch chan<- prom.Metric) error {
@@ -2070,18 +2179,28 @@ func (c *vipCollector) Update(ch chan<- prom.Metric) error {
 		return nil
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	var counters []VipCounter
 
 	if ebpfObjs != nil {
-		log.Debugf("VIP metrics: eBPF mode — collecting stats for %d VIPs", len(c.counters))
-		updateCountersByEbpf(c.counters)
+		func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+
+			log.Debugf("VIP metrics: eBPF mode — collecting stats for %d VIPs", len(c.counters))
+			updateCountersByEbpf(c.counters)
+			for _, counter := range c.counters {
+				if counter != nil {
+					counters = append(counters, *counter)
+				}
+			}
+		}()
 	} else {
-		log.Debugf("VIP metrics: conntrack mode — collecting stats for %d VIPs", len(c.counters))
-		c.updateCountersByConntrack()
+		c.maybeStartConntrackCollect()
+		counters = c.snapshotVipCounters()
+		log.Debugf("VIP metrics: conntrack mode — returning cached stats for %d VIPs", len(counters))
 	}
 
-	for _, rule := range c.counters {
+	for _, rule := range counters {
 		vipUuid := rule.VipUuid
 		ch <- prom.MustNewConstMetric(c.inByteEntry, prom.CounterValue, float64(rule.InBytes), vipUuid)
 		ch <- prom.MustNewConstMetric(c.inPktEntry, prom.CounterValue, float64(rule.InPackets), vipUuid)

--- a/plugin/vip_conntrack_test.go
+++ b/plugin/vip_conntrack_test.go
@@ -1,0 +1,95 @@
+package plugin
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestZSTAC84903ConntrackScanDoesNotHoldCollectorLock(t *testing.T) {
+	collector := &vipCollector{
+		previousStats: make(map[string]*SessionStat),
+		counters: map[string]*VipCounter{
+			"172.24.4.184": {VipUuid: "vip-uuid"},
+		},
+	}
+
+	reader, writer := io.Pipe()
+	defer writer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		collector.collectConntrackCounters(reader, map[string]string{"172.24.4.184": "vip-uuid"}, time.Now().Unix())
+	}()
+
+	locked := make(chan struct{})
+	go func() {
+		collector.mu.Lock()
+		collector.mu.Unlock()
+		close(locked)
+	}()
+
+	select {
+	case <-locked:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("conntrack scan blocked vipCollector.mu")
+	}
+
+	reader.Close()
+	<-done
+}
+
+func TestZSTAC84903ConntrackDeltasApplyToVipCounters(t *testing.T) {
+	collector := &vipCollector{
+		previousStats: make(map[string]*SessionStat),
+		counters: map[string]*VipCounter{
+			"172.24.4.184": {VipUuid: "vip-uuid"},
+		},
+	}
+
+	conntrack := strings.NewReader("ipv4 2 tcp 6 86390 ESTABLISHED src=10.0.0.1 dst=172.24.4.184 sport=12345 dport=80 packets=10 bytes=600 src=172.24.4.184 dst=10.0.0.1 sport=80 dport=12345 packets=8 bytes=480 mark=0 zone=0 use=2\n")
+	deltas, stats := collector.collectConntrackCounters(conntrack, map[string]string{"172.24.4.184": "vip-uuid"}, time.Now().Unix())
+	collector.applyConntrackDeltas(deltas)
+
+	if stats.matchedSessions != 1 {
+		t.Fatalf("expected 1 matched session, got %d", stats.matchedSessions)
+	}
+
+	counter := collector.counters["172.24.4.184"]
+	if counter.InPackets != 10 || counter.InBytes != 600 || counter.OutPackets != 8 || counter.OutBytes != 480 {
+		t.Fatalf("unexpected counter: %+v", counter)
+	}
+}
+
+func TestZSTAC84903RemoveVipClearsPreviousStats(t *testing.T) {
+	collector := &vipCollector{
+		previousStats: map[string]*SessionStat{
+			"vip-in": {
+				DstIp:      "172.24.4.184",
+				LastUpdate: time.Now().Unix(),
+			},
+			"vip-reply": {
+				ReplyDstIp: "172.24.4.184",
+				LastUpdate: time.Now().Unix(),
+			},
+			"other": {
+				DstIp:      "172.24.4.200",
+				LastUpdate: time.Now().Unix(),
+			},
+		},
+	}
+
+	collector.removePreviousStatsByVip("172.24.4.184")
+
+	if _, ok := collector.previousStats["vip-in"]; ok {
+		t.Fatal("expected previous inbound session to be removed")
+	}
+	if _, ok := collector.previousStats["vip-reply"]; ok {
+		t.Fatal("expected previous reply session to be removed")
+	}
+	if _, ok := collector.previousStats["other"]; !ok {
+		t.Fatal("unexpected unrelated session removal")
+	}
+}


### PR DESCRIPTION
## 修复说明

ZSTAC-84903 后续现场复现：VyOS 镜像上 /metrics 触发 VIP conntrack 全量扫描时，zvr CPU 升高并阻塞 /createvip。

## 根因

传统 VyOS 镜像不走 OpenEuler eBPF VIP counter，fallback 到 conntrack 轮询。旧逻辑在 Prometheus Update 路径同步扫描 /proc/net/nf_conntrack，并与 SetVip/RemoveVip 共享 vipCollector.mu，导致 /createvip 等待慢扫描完成。

## 变更

- conntrack 扫描改为后台异步采集。
- 扫描期间只使用 VIP snapshot，不持有 vipCollector.mu。
- /metrics 返回缓存 counter，不等待全量扫描。
- 扫描完成后短暂加锁合并 delta，保证 /createvip 不被慢扫描阻塞。
- 增加 ZSTAC-84903 回归测试覆盖锁不阻塞和 counter delta 合并。

## 测试

```text
ok command-line-arguments 0.008s
```

全 plugin 包测试当前受既有问题阻塞：plugin/vip_euler_test.go 引用不存在的 ParseVipCounterFromIptables。

sync from gitlab !1095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **优化改进**
  * VIP Prometheus 指标改为异步后台收集并缓存，Update 立即返回缓存以提升响应性；后台扫描受限频率并防止重入，会话过期默认 300 秒并会清理陈旧会话。
  * 在 VIP 移除时同时清理历史会话数据，避免遗留影响计数。
  * eBPF 模式保持同步行为不变。

* **测试**
  * 新增并发性、计数正确性与状态清理相关的单元测试。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatheMatrix/zstack-vyos/pull/266)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->