### PR TITLE
fix(ZSTAC-84903): align vip counter sampling

### DIFF
--- a/plugin/vip.go
+++ b/plugin/vip.go
@@ -1767,7 +1767,7 @@ var vipPromCollector *vipCollector
 
 const (
 	LABEL_VIP_UUID             = "VipUUID"
-	conntrackCollectInterval   = 15 * time.Second
+	conntrackCollectInterval   = 10 * time.Second
 	conntrackSessionStaleAfter = 300
 )
 

--- a/plugin/vip_conntrack_test.go
+++ b/plugin/vip_conntrack_test.go
@@ -63,6 +63,12 @@ func TestZSTAC84903ConntrackDeltasApplyToVipCounters(t *testing.T) {
 	}
 }
 
+func TestZSTAC84903ConntrackCollectIntervalMatchesMetricsScrape(t *testing.T) {
+	if conntrackCollectInterval != 10*time.Second {
+		t.Fatalf("expected conntrack collect interval to be 10s, got %s", conntrackCollectInterval)
+	}
+}
+
 func TestZSTAC84903RemoveVipClearsPreviousStats(t *testing.T) {
 	collector := &vipCollector{
 		previousStats: map[string]*SessionStat{


### PR DESCRIPTION
## Root Cause

VyOS fallback conntrack VIP counter collected every 15s while MN/Prometheus scrapes vRouter metrics every 10s. Under steady traffic this can make one scrape observe the accumulated delta and the next scrape observe no update.

## Fix

- Change conntrackCollectInterval from 15s to 10s
- Add a ZSTAC-84903 regression test to pin the interval

## Verification

Passed:
```
/usr/local/bin/go test -vet=off -mod=readonly $(/usr/local/bin/go list -f '{{range .GoFiles}}{{.}} {{end}}') vip_conntrack_test.go -run 'TestZSTAC84903' -count=1\n```\n\nNote: full plugin package go test is still blocked by existing unrelated vip_euler_test.go ParseVipCounterFromIptables undefined.

sync from gitlab !1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **改进**
  * 优化了VIP连接跟踪采集间隔至10秒，与指标采集周期更好地同步，提高了监控数据的准确性。

* **测试**
  * 新增验证测试，确保连接跟踪采集间隔配置的正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatheMatrix/zstack-vyos/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->