### PR TITLE
ZSTAC-85697 fix Euler vRouter IPv6-only ssh listen

### DIFF
--- a/plugin/snat_log.go
+++ b/plugin/snat_log.go
@@ -106,9 +106,7 @@ func getSnatLogRuntimeConfig() snatLogRuntimeConfig {
 	conf.MnPeerIP = getBootstrapStringValue("managementPeerNodeIp")
 
 	if mgmtNic, ok := utils.BootstrapInfo["managementNic"].(map[string]interface{}); ok {
-		if ip, ok := mgmtNic["ip"].(string); ok {
-			conf.MgmtIP = strings.TrimSpace(ip)
-		}
+		conf.MgmtIP = utils.GetManagementNicAddress(mgmtNic)
 	}
 
 	return conf

--- a/plugin/snat_log_test.go
+++ b/plugin/snat_log_test.go
@@ -123,6 +123,25 @@ func TestBuildSnatLogRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestGetSnatLogRuntimeConfigUsesIpv6OnlyManagementNic(t *testing.T) {
+	original := utils.BootstrapInfo
+	defer func() {
+		utils.BootstrapInfo = original
+	}()
+
+	utils.BootstrapInfo = map[string]interface{}{
+		"uuid": "vpc-uuid-1",
+		"managementNic": map[string]interface{}{
+			"ip6": "2001:db8::10",
+		},
+		"additionalNics": []interface{}{},
+	}
+
+	if conf := getSnatLogRuntimeConfig(); conf.MgmtIP != "2001:db8::10" {
+		t.Fatalf("expect IPv6-only management IP in runtime config, got %+v", conf)
+	}
+}
+
 func TestGetVpcDefaultPublicIpFromAdditionalNic(t *testing.T) {
 	original := utils.BootstrapInfo
 	defer func() {

--- a/utils/bootStrapInfo.go
+++ b/utils/bootStrapInfo.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,19 +203,12 @@ func GetVirtualRouterUuid() string {
 }
 
 func IsInManagementCidr(vipStr string) bool {
-	mgmtNic := BootstrapInfo["managementNic"].(map[string]interface{})
-	ipStr, _ := mgmtNic["ip"].(string)
-	netmaskStr, _ := mgmtNic["netmask"].(string)
+	mgmtNic, ok := BootstrapInfo["managementNic"].(map[string]interface{})
+	if !ok {
+		return false
+	}
 
-	ip := net.ParseIP(ipStr)
-	prefix, err := NetmaskToCIDR(netmaskStr)
-	PanicOnError(err)
-
-	_, cidr, err := net.ParseCIDR(fmt.Sprintf("%s/%d", ip, prefix))
-	PanicOnError(err)
-
-	vip := net.ParseIP(vipStr)
-	return cidr.Contains(vip)
+	return CheckMgmtCidrContainsIp(vipStr, mgmtNic)
 }
 
 func GetMnNodeIps() map[string]string {
@@ -284,8 +276,9 @@ func GetBootStrapNicInfo() map[string]Nic {
 		name, ok1 := mgmtNic["deviceName"].(string)
 		mac, ok2 := mgmtNic["mac"].(string)
 		ip, ok3 := mgmtNic["ip"].(string)
-		if ok1 && ok2 && ok3 {
-			mnic := Nic{Name: name, Mac: mac, Ip: ip}
+		ip6, ok4 := mgmtNic["ip6"].(string)
+		if ok1 && ok2 && (ok3 || ok4) {
+			mnic := Nic{Name: name, Mac: mac, Ip: ip, Ip6: ip6}
 			mnic.Catatory, _ = mgmtNic["category"].(string)
 			bootstrapNics[mnic.Name] = mnic
 		}

--- a/utils/bootstrap_info_ipv6_test.go
+++ b/utils/bootstrap_info_ipv6_test.go
@@ -19,4 +19,44 @@ var _ = Describe("bootstrap info ipv6", func() {
 
 		Expect(GetManagementNodeCidrs()).To(Equal([]string{"192.168.1.0/24", "2001:db8::/64"}))
 	})
+
+	It("checks IPv6-only management CIDR without IPv4 netmask", func() {
+		oldBootstrapInfo := BootstrapInfo
+		defer func() {
+			BootstrapInfo = oldBootstrapInfo
+		}()
+
+		BootstrapInfo = map[string]interface{}{
+			"managementNic": map[string]interface{}{
+				"ip6":          "2001:db8::10",
+				"prefixLength": float64(64),
+			},
+		}
+
+		Expect(IsInManagementCidr("2001:db8::20")).To(BeTrue())
+		Expect(IsInManagementCidr("2001:db9::20")).To(BeFalse())
+		Expect(IsInManagementCidr("192.168.1.20")).To(BeFalse())
+	})
+
+	It("keeps IPv6-only management NIC in bootstrap NIC inventory", func() {
+		oldBootstrapInfo := BootstrapInfo
+		defer func() {
+			BootstrapInfo = oldBootstrapInfo
+		}()
+
+		BootstrapInfo = map[string]interface{}{
+			"managementNic": map[string]interface{}{
+				"deviceName": "eth0",
+				"mac":        "fa:16:3e:00:00:01",
+				"category":   "Public",
+				"ip6":        "2001:db8::10",
+			},
+			"additionalNics": []interface{}{},
+		}
+
+		nics := GetBootStrapNicInfo()
+		Expect(nics).To(HaveKey("eth0"))
+		Expect(nics["eth0"].Ip).To(BeEmpty())
+		Expect(nics["eth0"].Ip6).To(Equal("2001:db8::10"))
+	})
 })

--- a/utils/net.go
+++ b/utils/net.go
@@ -499,6 +499,21 @@ func CheckMgmtCidrContainsIp(ip string, mgmtNic map[string]interface{}) bool {
 	return mgmtNet.Contains(net.ParseIP(ip))
 }
 
+func GetManagementNicAddress(mgmtNic map[string]interface{}) string {
+	if mgmtNic == nil {
+		return ""
+	}
+
+	ip, _ := mgmtNic["ip"].(string)
+	ip = strings.TrimSpace(ip)
+	if ip != "" {
+		return ip
+	}
+
+	ip6, _ := mgmtNic["ip6"].(string)
+	return strings.TrimSpace(ip6)
+}
+
 func GetMgmtGatewayForIp(ip string, mgmtNic map[string]interface{}) string {
 	if mgmtNic == nil {
 		return ""

--- a/utils/net_ipv6_test.go
+++ b/utils/net_ipv6_test.go
@@ -50,4 +50,15 @@ var _ = Describe("net ipv6", func() {
 
 		Expect(GetMgmtGatewayForIp("fd00:172:24:246::/64", mgmtNic)).To(Equal(""))
 	})
+
+	It("selects management NIC address with IPv4 preference and IPv6 fallback", func() {
+		Expect(GetManagementNicAddress(map[string]interface{}{
+			"ip":  "192.168.1.10",
+			"ip6": "2001:db8::10",
+		})).To(Equal("192.168.1.10"))
+
+		Expect(GetManagementNicAddress(map[string]interface{}{
+			"ip6": "2001:db8::10",
+		})).To(Equal("2001:db8::10"))
+	})
 })

--- a/zvr/zvr.go
+++ b/zvr/zvr.go
@@ -62,8 +62,17 @@ func initPlugins() {
 
 type nic struct {
 	ip       string
+	ip6      string
 	name     string
 	category string
+}
+
+func nicFirewallAddress(nic *nic) string {
+	if nic.ip != "" {
+		return nic.ip
+	}
+
+	return nic.ip6
 }
 
 // Note: there shouldn't be 'daily' etc. in the following config files.
@@ -263,8 +272,8 @@ func checkIptablesRules() {
 	eth0 := &nic{name: "eth0"}
 	var ok bool
 	eth0.ip, ok = mgmtNic["ip"].(string)
-	_, ok = mgmtNic["ip"].(string)
-	_, ok6 := mgmtNic["ip6"].(string)
+	var ok6 bool
+	eth0.ip6, ok6 = mgmtNic["ip6"].(string)
 	utils.PanicIfError(ok || ok6, fmt.Errorf("cannot find 'ip' field for the nic[name:%s]", eth0.name))
 
 	if mgmtNic["l2type"] != nil {
@@ -282,8 +291,7 @@ func checkIptablesRules() {
 			utils.PanicIfError(ok, fmt.Errorf("cannot find 'deviceName' field for the nic"))
 
 			n.ip, ok = onic["ip"].(string)
-			_, ok := onic["ip"].(string)
-			_, ok6 := onic["ip6"].(string)
+			n.ip6, ok6 = onic["ip6"].(string)
 			utils.PanicIfError(ok || ok6, fmt.Errorf("cannot find 'ip' field for the nic[name:%s]", n.name))
 
 			if onic["l2type"] != nil {
@@ -296,10 +304,15 @@ func checkIptablesRules() {
 
 	for _, nic := range nics {
 		var err error
+		address := nicFirewallAddress(nic)
+		if address == "" {
+			log.Debugf("skip InitNicFirewall for nic %s without IP address", nic.name)
+			continue
+		}
 		if nic.category == "Private" {
-			err = utils.InitNicFirewall(nic.name, nic.ip, false, utils.IPTABLES_ACTION_REJECT)
+			err = utils.InitNicFirewall(nic.name, address, false, utils.IPTABLES_ACTION_REJECT)
 		} else {
-			err = utils.InitNicFirewall(nic.name, nic.ip, true, utils.IPTABLES_ACTION_REJECT)
+			err = utils.InitNicFirewall(nic.name, address, true, utils.IPTABLES_ACTION_REJECT)
 		}
 		if err != nil {
 			log.Debugf("InitNicFirewall for nic: %s failed", err.Error())

--- a/zvr/zvr_test.go
+++ b/zvr/zvr_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestNicFirewallAddressUsesIpv6Fallback(t *testing.T) {
+	if got := nicFirewallAddress(&nic{ip6: "2001:db8::10"}); got != "2001:db8::10" {
+		t.Fatalf("expect IPv6 fallback address, got %s", got)
+	}
+
+	if got := nicFirewallAddress(&nic{ip: "192.168.1.10", ip6: "2001:db8::10"}); got != "192.168.1.10" {
+		t.Fatalf("expect IPv4 address to be preferred, got %s", got)
+	}
+}

--- a/zvrboot/zvrboot_test.go
+++ b/zvrboot/zvrboot_test.go
@@ -21,6 +21,13 @@ var _ = Describe("zvrboot_test", func() {
 		Expect(nicSSHListenAddress(n)).To(Equal("2001:db8::10"))
 		Expect(setDestinationAddress([]string{"action accept"}, nicIPv4FirewallAddress(n))).To(Equal([]string{"action accept"}))
 	})
+	It("[REPLACE_VYOS] euler zvrboot: ipv6-only management nic uses IPv6 ssh listen address", func() {
+		n := &utils.NicInfo{Ip6: "2001:db8::10"}
+		Expect(managementNicSshListenAddress(n)).To(Equal("2001:db8::10"))
+
+		n.Ip = "192.168.1.10"
+		Expect(managementNicSshListenAddress(n)).To(Equal("192.168.1.10"))
+	})
 	It("[REPLACE_VYOS] zvrboot: skip empty firewall address", func() {
 		Expect(setDestinationAddress([]string{"action accept"}, "")).To(Equal([]string{"action accept"}))
 	})

--- a/zvrboot/zvrboot_test.go
+++ b/zvrboot/zvrboot_test.go
@@ -24,9 +24,11 @@ var _ = Describe("zvrboot_test", func() {
 	It("[REPLACE_VYOS] euler zvrboot: ipv6-only management nic uses IPv6 ssh listen address", func() {
 		n := &utils.NicInfo{Ip6: "2001:db8::10"}
 		Expect(managementNicSshListenAddress(n)).To(Equal("2001:db8::10"))
+		Expect(nicInfoFirewallAddress(n)).To(Equal("2001:db8::10"))
 
 		n.Ip = "192.168.1.10"
 		Expect(managementNicSshListenAddress(n)).To(Equal("192.168.1.10"))
+		Expect(nicInfoFirewallAddress(n)).To(Equal("192.168.1.10"))
 	})
 	It("[REPLACE_VYOS] zvrboot: skip empty firewall address", func() {
 		Expect(setDestinationAddress([]string{"action accept"}, "")).To(Equal([]string{"action accept"}))

--- a/zvrboot/zvrboot_utils.go
+++ b/zvrboot/zvrboot_utils.go
@@ -257,6 +257,13 @@ func managementNicSshListenAddress(nic *utils.NicInfo) string {
 	return nic.Ip6
 }
 
+func nicInfoFirewallAddress(nic *utils.NicInfo) string {
+	if nic.Ip != "" {
+		return nic.Ip
+	}
+	return nic.Ip6
+}
+
 func configureRadvdServer() {
 	log.Debugf("[configure: radvd service]")
 	radvdMap := make(utils.RadvdAttrsMap)
@@ -402,10 +409,11 @@ func configureBondNic(nic *utils.NicInfo) {
 	}
 
 	// Initialize firewall for bond interface
+	firewallAddress := nicInfoFirewallAddress(nic)
 	if nic.Category == "Private" {
-		err = utils.InitNicFirewall(bondName, nic.Ip, false, utils.IPTABLES_ACTION_REJECT)
+		err = utils.InitNicFirewall(bondName, firewallAddress, false, utils.IPTABLES_ACTION_REJECT)
 	} else {
-		err = utils.InitNicFirewall(bondName, nic.Ip, true, utils.IPTABLES_ACTION_REJECT)
+		err = utils.InitNicFirewall(bondName, firewallAddress, true, utils.IPTABLES_ACTION_REJECT)
 	}
 	if err != nil {
 		log.Debugf("InitNicFirewall for bond: %s failed", err.Error())
@@ -501,10 +509,11 @@ func configureNicInfo(nic *utils.NicInfo) {
 	}
 	addManagementNodeRoutes(nic, nic.Name)
 
+	firewallAddress := nicInfoFirewallAddress(nic)
 	if nic.Category == "Private" {
-		err = utils.InitNicFirewall(nic.Name, nic.Ip, false, utils.IPTABLES_ACTION_REJECT)
+		err = utils.InitNicFirewall(nic.Name, firewallAddress, false, utils.IPTABLES_ACTION_REJECT)
 	} else {
-		err = utils.InitNicFirewall(nic.Name, nic.Ip, true, utils.IPTABLES_ACTION_REJECT)
+		err = utils.InitNicFirewall(nic.Name, firewallAddress, true, utils.IPTABLES_ACTION_REJECT)
 	}
 	if err != nil {
 		log.Debugf("InitNicFirewall for nic: %s failed", err.Error())

--- a/zvrboot/zvrboot_utils.go
+++ b/zvrboot/zvrboot_utils.go
@@ -237,7 +237,7 @@ func configureSshServer() {
 	sshkey := utils.BootstrapInfo["publicKey"].(string)
 	utils.Assert(sshkey != "", "cannot find 'publicKey' in bootstrap info")
 	sshport := utils.BootstrapInfo["sshPort"].(float64)
-	address := mgmtNic.Ip
+	address := managementNicSshListenAddress(mgmtNic)
 	utils.Assert(address != "", "cannot find eth0 ip address in bootstrap info")
 	passwordAuthentication := "no"
 	if _, ok := utils.BootstrapInfo["allowPasswordAuth"].(string); ok {
@@ -248,6 +248,13 @@ func configureSshServer() {
 	sshInfo.SetPasswordAuthentication(passwordAuthentication)
 	err := sshInfo.ConfigService()
 	utils.Assertf(err == nil, "configure SSH Server error: %s", err)
+}
+
+func managementNicSshListenAddress(nic *utils.NicInfo) string {
+	if nic.Ip != "" {
+		return nic.Ip
+	}
+	return nic.Ip6
 }
 
 func configureRadvdServer() {


### PR DESCRIPTION
Fix: IPv6-only Euler vRouter management NIC failed in zvrboot ssh config.

Root cause: configureSshServer only read managementNic.Ip. For IPv6-only bootstrap info the value is empty and zvrboot panicked before zvr/zsn agent startup.

Verification:
- go test ./zvrboot -run TestZvrboot -ginkgo.focus euler-zvrboot
- go test ./utils -run TestSshd
- Rebuilt Euler qcow2 and created VPC Router 76ef02c3dc5a44b5a971bb24968c7415. Router is Running/Connected with IPv6 2026:3:3:1::65:3e24.
- MN/host ping6 succeeded; TCP 22 and 7272 open; zvr.log ping callbacks succeeded.

Jira: http://jira.zstack.io/browse/ZSTAC-85697
Parent: http://jira.zstack.io/browse/ZSTAC-85504

sync from gitlab !1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 管理网口与防火墙初始化现在支持仅 IPv6 的场景，地址选择优先 IPv4、不可用则降级至 IPv6。
  * 运行时配置与日志组件在仅有 IPv6 管理网口时能正确使用 IPv6 地址。
  * 管理网段判断与引导信息解析已增强以识别 IPv6 管理网口并保留仅 IPv6 的网卡信息。

* **测试**
  * 新增多项测试，覆盖仅 IPv6 与 IPv4/IPv6 共存情况下的地址选择与行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->