### PR TITLE
<fix>[vyos]: render dnsmasq query limits

### DIFF
--- a/plugin/dns.go
+++ b/plugin/dns.go
@@ -20,9 +20,7 @@ type dnsInfo struct {
 }
 
 type setDnsCmd struct {
-	Dns           []dnsInfo `json:"dns"`
-	DnsForwardMax int       `json:"dnsForwardMax"`
-	CacheSize     int       `json:"cacheSize"`
+	Dns []dnsInfo `json:"dns"`
 }
 
 type removeDnsCmd struct {
@@ -88,7 +86,7 @@ func setDnsHandler(ctx *server.CommandContext) interface{} {
 }
 
 func setDns(cmd *setDnsCmd) interface{} {
-	setDnsmasqOptions(cmd.DnsForwardMax, cmd.CacheSize)
+	resetDnsmasqOptions()
 	dnsByMac := make(map[string][]dnsInfo)
 	for _, info := range cmd.Dns {
 		dns := dnsByMac[info.NicMac]
@@ -150,6 +148,7 @@ func removeDnsHandler(ctx *server.CommandContext) interface{} {
 }
 
 func removeDns(cmd *removeDnsCmd) interface{} {
+	resetDnsmasqOptions()
 	for _, info := range cmd.Dns {
 		delete(dnsServers, info.DnsAddress)
 	}

--- a/plugin/dns.go
+++ b/plugin/dns.go
@@ -20,7 +20,9 @@ type dnsInfo struct {
 }
 
 type setDnsCmd struct {
-	Dns []dnsInfo `json:"dns"`
+	Dns           []dnsInfo `json:"dns"`
+	DnsForwardMax int       `json:"dnsForwardMax"`
+	CacheSize     int       `json:"cacheSize"`
 }
 
 type removeDnsCmd struct {
@@ -28,8 +30,10 @@ type removeDnsCmd struct {
 }
 
 type setVpcDnsCmd struct {
-	Dns    []string `json:"dns"`
-	NicMac []string `json:"nicMac"`
+	Dns           []string `json:"dns"`
+	NicMac        []string `json:"nicMac"`
+	DnsForwardMax int      `json:"dnsForwardMax"`
+	CacheSize     int      `json:"cacheSize"`
 }
 
 var dnsServers map[string]string
@@ -84,6 +88,7 @@ func setDnsHandler(ctx *server.CommandContext) interface{} {
 }
 
 func setDns(cmd *setDnsCmd) interface{} {
+	setDnsmasqOptions(cmd.DnsForwardMax, cmd.CacheSize)
 	dnsByMac := make(map[string][]dnsInfo)
 	for _, info := range cmd.Dns {
 		dns := dnsByMac[info.NicMac]
@@ -163,6 +168,7 @@ func setVpcDnsHandler(ctx *server.CommandContext) interface{} {
 }
 
 func setVpcDns(cmd *setVpcDnsCmd) interface{} {
+	setDnsmasqOptions(cmd.DnsForwardMax, cmd.CacheSize)
 	var tree *server.VyosConfigTree
 	if !utils.IsSkipVyosIptables() {
 		tree = server.NewParserFromShowConfiguration().Tree

--- a/plugin/dnsmasq.go
+++ b/plugin/dnsmasq.go
@@ -20,8 +20,9 @@ const (
 	DNSMASQ_RESOLV_FILE = "/etc/resolv.conf"
 	DNSMASQ_PID_FILE    = "/var/run/dnsmasq.pid"
 
-	DEFAULT_DNS_FORWARD_MAX = 1000
-	DEFAULT_DNS_CACHE_SIZE  = 10000
+	DEFAULT_DNS_FORWARD_MAX       = 1000
+	DEFAULT_DNS_CACHE_SIZE        = 10000
+	DEFAULT_LEGACY_DNS_CACHE_SIZE = 150
 )
 
 func getDnsmasqPidFileTemp() string {
@@ -46,8 +47,12 @@ const dnsmasqTemplate = `#
 log-facility=/var/log/dnsmasq.log
 no-poll
 edns-packet-max=4096
+{{ if .UseDnsmasqOptions }}
 dns-forward-max={{.DnsForwardMax}}
 cache-size={{.CacheSize}}
+{{ else }}
+cache-size={{.CacheSize}}
+{{ end }}
 bind-interfaces
 interface=lo
 {{ range $index, $name := .NicNames }}
@@ -64,18 +69,21 @@ nameserver {{$ip}}
 {{ end }}`
 
 type DnsmasqConf struct {
-	NicNames      []string
-	DnsServers    []string
-	DnsForwardMax int
-	CacheSize     int
+	NicNames          []string
+	DnsServers        []string
+	DnsForwardMax     int
+	CacheSize         int
+	UseDnsmasqOptions bool
 }
 
 var (
-	currentDnsForwardMax = DEFAULT_DNS_FORWARD_MAX
-	currentDnsCacheSize  = DEFAULT_DNS_CACHE_SIZE
+	currentDnsForwardMax     = DEFAULT_DNS_FORWARD_MAX
+	currentDnsCacheSize      = DEFAULT_DNS_CACHE_SIZE
+	currentUseDnsmasqOptions = false
 )
 
 func setDnsmasqOptions(dnsForwardMax, cacheSize int) {
+	currentUseDnsmasqOptions = true
 	if dnsForwardMax > 0 {
 		currentDnsForwardMax = dnsForwardMax
 	}
@@ -84,11 +92,35 @@ func setDnsmasqOptions(dnsForwardMax, cacheSize int) {
 	}
 }
 
+func resetDnsmasqOptions() {
+	currentUseDnsmasqOptions = false
+	currentDnsForwardMax = DEFAULT_DNS_FORWARD_MAX
+	currentDnsCacheSize = DEFAULT_DNS_CACHE_SIZE
+}
+
 func NewDnsmasq(nics, servers map[string]string) *DnsmasqConf {
-	return NewDnsmasqWithOptions(nics, servers, currentDnsForwardMax, currentDnsCacheSize)
+	if currentUseDnsmasqOptions {
+		return NewDnsmasqWithOptions(nics, servers, currentDnsForwardMax, currentDnsCacheSize)
+	}
+
+	return NewDnsmasqWithCacheSize(nics, servers, DEFAULT_LEGACY_DNS_CACHE_SIZE)
 }
 
 func NewDnsmasqWithOptions(nics, servers map[string]string, dnsForwardMax, cacheSize int) *DnsmasqConf {
+	if dnsForwardMax <= 0 {
+		dnsForwardMax = DEFAULT_DNS_FORWARD_MAX
+	}
+	if cacheSize <= 0 {
+		cacheSize = DEFAULT_DNS_CACHE_SIZE
+	}
+
+	dnsmasq := NewDnsmasqWithCacheSize(nics, servers, cacheSize)
+	dnsmasq.DnsForwardMax = dnsForwardMax
+	dnsmasq.UseDnsmasqOptions = true
+	return dnsmasq
+}
+
+func NewDnsmasqWithCacheSize(nics, servers map[string]string, cacheSize int) *DnsmasqConf {
 	var nicNames, ips []string
 	for nic, _ := range nics {
 		nicNames = append(nicNames, nic)
@@ -98,14 +130,11 @@ func NewDnsmasqWithOptions(nics, servers map[string]string, dnsForwardMax, cache
 		ips = append(ips, ip)
 	}
 
-	if dnsForwardMax <= 0 {
-		dnsForwardMax = DEFAULT_DNS_FORWARD_MAX
-	}
 	if cacheSize <= 0 {
-		cacheSize = DEFAULT_DNS_CACHE_SIZE
+		cacheSize = DEFAULT_LEGACY_DNS_CACHE_SIZE
 	}
 
-	return &DnsmasqConf{NicNames: nicNames, DnsServers: ips, DnsForwardMax: dnsForwardMax, CacheSize: cacheSize}
+	return &DnsmasqConf{NicNames: nicNames, DnsServers: ips, CacheSize: cacheSize}
 }
 
 func (d *DnsmasqConf) RestartDnsmasq() error {

--- a/plugin/dnsmasq.go
+++ b/plugin/dnsmasq.go
@@ -19,6 +19,9 @@ const (
 	DNSMASQ_CONF_PATH   = "/etc/dnsmasq.conf"
 	DNSMASQ_RESOLV_FILE = "/etc/resolv.conf"
 	DNSMASQ_PID_FILE    = "/var/run/dnsmasq.pid"
+
+	DEFAULT_DNS_FORWARD_MAX = 1000
+	DEFAULT_DNS_CACHE_SIZE  = 10000
 )
 
 func getDnsmasqPidFileTemp() string {
@@ -43,7 +46,8 @@ const dnsmasqTemplate = `#
 log-facility=/var/log/dnsmasq.log
 no-poll
 edns-packet-max=4096
-cache-size=150
+dns-forward-max={{.DnsForwardMax}}
+cache-size={{.CacheSize}}
 bind-interfaces
 interface=lo
 {{ range $index, $name := .NicNames }}
@@ -60,11 +64,31 @@ nameserver {{$ip}}
 {{ end }}`
 
 type DnsmasqConf struct {
-	NicNames   []string
-	DnsServers []string
+	NicNames      []string
+	DnsServers    []string
+	DnsForwardMax int
+	CacheSize     int
+}
+
+var (
+	currentDnsForwardMax = DEFAULT_DNS_FORWARD_MAX
+	currentDnsCacheSize  = DEFAULT_DNS_CACHE_SIZE
+)
+
+func setDnsmasqOptions(dnsForwardMax, cacheSize int) {
+	if dnsForwardMax > 0 {
+		currentDnsForwardMax = dnsForwardMax
+	}
+	if cacheSize > 0 {
+		currentDnsCacheSize = cacheSize
+	}
 }
 
 func NewDnsmasq(nics, servers map[string]string) *DnsmasqConf {
+	return NewDnsmasqWithOptions(nics, servers, currentDnsForwardMax, currentDnsCacheSize)
+}
+
+func NewDnsmasqWithOptions(nics, servers map[string]string, dnsForwardMax, cacheSize int) *DnsmasqConf {
 	var nicNames, ips []string
 	for nic, _ := range nics {
 		nicNames = append(nicNames, nic)
@@ -74,7 +98,14 @@ func NewDnsmasq(nics, servers map[string]string) *DnsmasqConf {
 		ips = append(ips, ip)
 	}
 
-	return &DnsmasqConf{NicNames: nicNames, DnsServers: ips}
+	if dnsForwardMax <= 0 {
+		dnsForwardMax = DEFAULT_DNS_FORWARD_MAX
+	}
+	if cacheSize <= 0 {
+		cacheSize = DEFAULT_DNS_CACHE_SIZE
+	}
+
+	return &DnsmasqConf{NicNames: nicNames, DnsServers: ips, DnsForwardMax: dnsForwardMax, CacheSize: cacheSize}
 }
 
 func (d *DnsmasqConf) RestartDnsmasq() error {


### PR DESCRIPTION
Parse dnsForwardMax and cacheSize in DNS commands.
Render both values into generated dnsmasq.conf.

Resolves: ZSTAC-85197

Change-Id: I65131dfd4dfc673a6751096eadde86259b1f61d6

sync from gitlab !1131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新特性

- 新增 DNS 参数配置功能，支持自定义 DNS 转发最大连接数和缓存大小
- 增强配置管理能力，支持参数模式与兼容模式的灵活切换

<!-- end of auto-generated comment: release notes by coderabbit.ai -->