### PR TITLE
[ZSTAC-86026][4.8.38] backport firewall diff rules

### DIFF
--- a/plugin/firewall.go
+++ b/plugin/firewall.go
@@ -981,6 +981,10 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 		desiredRuleSetNames[ruleSetName] = struct{}{}
 		desiredByKey[fmt.Sprintf("%s//%s", ref.Mac, ref.Forward)] = desiredRuleSetCtx{nicName: nicName, ruleSetName: ruleSetName}
 
+		if tree.Getf("firewall name %s", ruleSetName) == nil {
+			continue
+		}
+
 		currentActionType := ""
 		if actionNode := tree.Getf("firewall name %s default-action", ruleSetName); actionNode != nil {
 			currentActionType = actionNode.Value()

--- a/plugin/firewall.go
+++ b/plugin/firewall.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -245,6 +246,234 @@ func isDefaultRule(n string) bool {
 
 func buildRuleSetName(nicName string, forward string) string {
 	return fmt.Sprintf("%s.%s", nicName, strings.ToLower(forward))
+}
+
+type ruleSetDiff struct {
+	Mac            string
+	Forward        string
+	RuleSetExists  bool
+	ActionChanged  bool
+	LogChanged     bool
+	DesiredRuleSet ruleSetInfo
+	RulesToAdd     []ruleInfo
+	RulesToDelete  []ruleInfo
+	RulesToUpdate  []ruleInfo
+}
+
+func readCurrentUserRules(tree *server.VyosConfigTree, ruleSetName string) []ruleInfo {
+	rules := make([]ruleInfo, 0)
+	ruleNode := tree.Getf("firewall name %s rule", ruleSetName)
+	if ruleNode == nil {
+		return rules
+	}
+
+	for _, rc := range ruleNode.Children() {
+		if isDefaultRule(rc.Name()) {
+			continue
+		}
+
+		ruleNumber := getRuleNumber(rc)
+		sourceIP := getIp(rc, "source")
+		destIP := getIp(rc, "destination")
+
+		rules = append(rules, ruleInfo{
+			RuleNumber:  ruleNumber,
+			Action:      rc.GetChildrenValue("action"),
+			Protocol:    rc.GetChildrenValue("protocol"),
+			Tcp:         rc.GetChildrenValue("tcp flags"),
+			Icmp:        rc.GetChildrenValue("icmp type-name"),
+			EnableLog:   rc.GetChildrenValue("log") == "enable",
+			State:       getRuleState(rc),
+			SourcePort:  rc.GetChildrenValue("source port"),
+			DestPort:    rc.GetChildrenValue("destination port"),
+			DestIp:      resolveRuleIPValue(tree, ruleSetName, ruleNumber, FIREWALL_RULE_DEST_GROUP_SUFFIX, destIP),
+			SourceIp:    resolveRuleIPValue(tree, ruleSetName, ruleNumber, FIREWALL_RULE_SOURCE_GROUP_SUFFIX, sourceIP),
+			AllowStates: getAllowStates(rc),
+			IsDefault:   false,
+		})
+	}
+
+	return rules
+}
+
+func resolveRuleIPValue(tree *server.VyosConfigTree, ruleSetName string, ruleNumber int, suffix, value string) string {
+	if !isLikelyRuleGroupName(ruleSetName, ruleNumber, suffix, value) {
+		return value
+	}
+
+	groupNode := tree.FindGroupByName(value, "address")
+	if groupNode == nil {
+		return value
+	}
+
+	members := make([]string, 0)
+	for _, child := range groupNode.Children() {
+		members = append(members, child.Name())
+	}
+	sort.Strings(members)
+	return strings.Join(members, IP_SPLIT)
+}
+
+func isLikelyRuleGroupName(ruleSetName string, ruleNumber int, suffix, value string) bool {
+	if value == "" || strings.Contains(value, "/") || strings.Contains(value, IP_SPLIT) {
+		return false
+	}
+	if net.ParseIP(value) != nil {
+		return false
+	}
+	if _, _, err := net.ParseCIDR(value); err == nil {
+		return false
+	}
+
+	expected := fmt.Sprintf("%s-%d-%s", ruleSetName, ruleNumber, suffix)
+	if strings.EqualFold(value, expected) {
+		return true
+	}
+
+	if strings.HasSuffix(value, fmt.Sprintf("-%s", suffix)) {
+		return true
+	}
+
+	return false
+}
+
+func normalizeCSV(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	parts := strings.Split(value, IP_SPLIT)
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	if len(normalized) == 0 {
+		return ""
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, IP_SPLIT)
+}
+
+func normalizeProtocol(protocol string) string {
+	protocol = strings.ToLower(strings.TrimSpace(protocol))
+	if protocol == "" {
+		return "all"
+	}
+	return protocol
+}
+
+func (r ruleInfo) Equal(other ruleInfo) bool {
+	return r.Action == other.Action &&
+		normalizeProtocol(r.Protocol) == normalizeProtocol(other.Protocol) &&
+		r.DestPort == other.DestPort &&
+		r.SourcePort == other.SourcePort &&
+		r.Tcp == other.Tcp &&
+		r.Icmp == other.Icmp &&
+		r.RuleNumber == other.RuleNumber &&
+		r.EnableLog == other.EnableLog &&
+		r.State == other.State &&
+		r.IsDefault == other.IsDefault &&
+		normalizeCSV(r.AllowStates) == normalizeCSV(other.AllowStates) &&
+		normalizeCSV(r.SourceIp) == normalizeCSV(other.SourceIp) &&
+		normalizeCSV(r.DestIp) == normalizeCSV(other.DestIp)
+}
+
+func equalRuleSetMeta(a, b ruleSetInfo) bool {
+	return strings.EqualFold(a.ActionType, b.ActionType) && a.EnableDefaultLog == b.EnableDefaultLog
+}
+
+func isUserRule(rule ruleInfo) bool {
+	if rule.IsDefault {
+		return false
+	}
+	return !isDefaultRule(strconv.Itoa(rule.RuleNumber))
+}
+
+func sortRulesByNumber(rules []ruleInfo) {
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].RuleNumber < rules[j].RuleNumber
+	})
+}
+
+func diffUserRules(current, desired []ethRuleSetRef) []ruleSetDiff {
+	currentIndex := make(map[string]ethRuleSetRef)
+	for _, ref := range current {
+		key := fmt.Sprintf("%s//%s", ref.Mac, ref.Forward)
+		currentIndex[key] = ref
+	}
+
+	diffs := make([]ruleSetDiff, 0, len(desired))
+	for _, desiredRef := range desired {
+		diff := ruleSetDiff{
+			Mac:            desiredRef.Mac,
+			Forward:        desiredRef.Forward,
+			DesiredRuleSet: desiredRef.RuleSetInfo,
+			RulesToAdd:     make([]ruleInfo, 0),
+			RulesToDelete:  make([]ruleInfo, 0),
+			RulesToUpdate:  make([]ruleInfo, 0),
+		}
+
+		desiredByNumber := make(map[int]ruleInfo)
+		for _, rule := range desiredRef.RuleSetInfo.Rules {
+			if !isUserRule(rule) {
+				continue
+			}
+			desiredByNumber[rule.RuleNumber] = rule
+		}
+
+		key := fmt.Sprintf("%s//%s", desiredRef.Mac, desiredRef.Forward)
+		currentRef, exists := currentIndex[key]
+		if !exists {
+			diff.RuleSetExists = false
+			for _, rule := range desiredByNumber {
+				diff.RulesToAdd = append(diff.RulesToAdd, rule)
+			}
+			sortRulesByNumber(diff.RulesToAdd)
+			diffs = append(diffs, diff)
+			continue
+		}
+
+		diff.RuleSetExists = true
+		if !equalRuleSetMeta(currentRef.RuleSetInfo, desiredRef.RuleSetInfo) {
+			diff.ActionChanged = !strings.EqualFold(currentRef.RuleSetInfo.ActionType, desiredRef.RuleSetInfo.ActionType)
+			diff.LogChanged = currentRef.RuleSetInfo.EnableDefaultLog != desiredRef.RuleSetInfo.EnableDefaultLog
+		}
+
+		currentByNumber := make(map[int]ruleInfo)
+		for _, rule := range currentRef.RuleSetInfo.Rules {
+			if !isUserRule(rule) {
+				continue
+			}
+			currentByNumber[rule.RuleNumber] = rule
+		}
+
+		for number, desiredRule := range desiredByNumber {
+			currentRule, ok := currentByNumber[number]
+			if !ok {
+				diff.RulesToAdd = append(diff.RulesToAdd, desiredRule)
+				continue
+			}
+			if !currentRule.Equal(desiredRule) {
+				diff.RulesToUpdate = append(diff.RulesToUpdate, desiredRule)
+			}
+		}
+
+		for number, currentRule := range currentByNumber {
+			if _, ok := desiredByNumber[number]; !ok {
+				diff.RulesToDelete = append(diff.RulesToDelete, currentRule)
+			}
+		}
+
+		sortRulesByNumber(diff.RulesToAdd)
+		sortRulesByNumber(diff.RulesToDelete)
+		sortRulesByNumber(diff.RulesToUpdate)
+		diffs = append(diffs, diff)
+	}
+
+	return diffs
 }
 
 func getRuleNumber(t *server.VyosConfigNode) int {
@@ -716,22 +945,125 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 		return nil
 	}
 
-	deleteOldRules()
-
 	tree := server.NewParserFromShowConfiguration().Tree
+
+	type desiredRuleSetCtx struct {
+		nicName     string
+		ruleSetName string
+	}
+
+	currentRefs := make([]ethRuleSetRef, 0, len(cmd.Refs))
+	desiredRuleSetNames := make(map[string]struct{})
+	desiredByKey := make(map[string]desiredRuleSetCtx)
+
 	for _, ref := range cmd.Refs {
-		nic, err := utils.GetNicNameByMac(ref.Mac)
+		nicName, err := utils.GetNicNameByMac(ref.Mac)
 		utils.PanicOnError(err)
-		ruleSetName := buildRuleSetName(nic, ref.Forward)
+		ruleSetName := buildRuleSetName(nicName, ref.Forward)
+		desiredRuleSetNames[ruleSetName] = struct{}{}
+		desiredByKey[fmt.Sprintf("%s//%s", ref.Mac, ref.Forward)] = desiredRuleSetCtx{nicName: nicName, ruleSetName: ruleSetName}
 
-		//create ruleSet
-		tree.CreateFirewallRuleSet(ruleSetName, ref.RuleSetInfo.toRules())
+		currentActionType := ""
+		if actionNode := tree.Getf("firewall name %s default-action", ruleSetName); actionNode != nil {
+			currentActionType = actionNode.Value()
+		}
 
-		//attach ruleset to nic
-		tree.AttachRuleSetOnInterface(nic, ref.Forward, ruleSetName)
+		currentRefs = append(currentRefs, ethRuleSetRef{
+			Mac:     ref.Mac,
+			Forward: ref.Forward,
+			RuleSetInfo: ruleSetInfo{
+				Name:             ruleSetName,
+				ActionType:       currentActionType,
+				EnableDefaultLog: tree.Getf("firewall name %s enable-default-log", ruleSetName) != nil,
+				Rules:            readCurrentUserRules(tree, ruleSetName),
+			},
+		})
+	}
 
-		//create address group
-		for _, rule := range ref.RuleSetInfo.Rules {
+	diffs := diffUserRules(currentRefs, cmd.Refs)
+
+	extraRuleSetNames := make([]string, 0)
+	if firewallNameNode := tree.Get("firewall name"); firewallNameNode != nil {
+		for _, ruleSetNode := range firewallNameNode.Children() {
+			ruleSetName := ruleSetNode.Name()
+			if _, ok := desiredRuleSetNames[ruleSetName]; !ok {
+				extraRuleSetNames = append(extraRuleSetNames, ruleSetName)
+			}
+		}
+	}
+
+	hasChanges := len(extraRuleSetNames) > 0
+	if !hasChanges {
+		for _, diff := range diffs {
+			if !diff.RuleSetExists || diff.ActionChanged || diff.LogChanged || len(diff.RulesToAdd) > 0 || len(diff.RulesToDelete) > 0 || len(diff.RulesToUpdate) > 0 {
+				hasChanges = true
+				break
+			}
+		}
+	}
+
+	if !hasChanges {
+		log.Debug("no firewall changes needed")
+		return nil
+	}
+
+	for _, diff := range diffs {
+		key := fmt.Sprintf("%s//%s", diff.Mac, diff.Forward)
+		ctx := desiredByKey[key]
+		ruleSetName := ctx.ruleSetName
+		nicName := ctx.nicName
+
+		log.Debugf("applyUserRules: %d adds, %d deletes, %d updates for ruleset %s", len(diff.RulesToAdd), len(diff.RulesToDelete), len(diff.RulesToUpdate), ruleSetName)
+
+		if !diff.RuleSetExists {
+			tree.CreateFirewallRuleSet(ruleSetName, diff.DesiredRuleSet.toRules())
+			tree.AttachRuleSetOnInterface(nicName, diff.Forward, ruleSetName)
+		}
+
+		if diff.RuleSetExists && diff.ActionChanged {
+			tree.SetFirewalRuleSetAction(ruleSetName, diff.DesiredRuleSet.ActionType)
+			tree.AttachRuleSetOnInterface(nicName, diff.Forward, ruleSetName)
+		}
+
+		if diff.RuleSetExists && diff.LogChanged {
+			if diff.DesiredRuleSet.EnableDefaultLog {
+				tree.Setf("firewall name %s enable-default-log", ruleSetName)
+			} else {
+				tree.Deletef("firewall name %s enable-default-log", ruleSetName)
+			}
+		}
+
+		for _, rule := range diff.RulesToDelete {
+			if sourceGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), "address"); sourceGroupNode != nil {
+				sourceGroupNode.Delete()
+			}
+			if destGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), "address"); destGroupNode != nil {
+				destGroupNode.Delete()
+			}
+			tree.Deletef("firewall name %s rule %v", ruleSetName, rule.RuleNumber)
+		}
+
+		for _, rule := range diff.RulesToAdd {
+			if rule.SourceIp != "" && strings.ContainsAny(rule.SourceIp, IP_SPLIT) {
+				log.Debug(rule.toGroups(FIREWALL_RULE_SOURCE_GROUP_SUFFIX))
+				tree.SetGroupsCheckExisting("address", rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), rule.toGroups(FIREWALL_RULE_SOURCE_GROUP_SUFFIX))
+			}
+			if rule.DestIp != "" && strings.ContainsAny(rule.DestIp, IP_SPLIT) {
+				log.Debug(rule.toGroups(FIREWALL_RULE_DEST_GROUP_SUFFIX))
+				tree.SetGroupsCheckExisting("address", rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), rule.toGroups(FIREWALL_RULE_DEST_GROUP_SUFFIX))
+			}
+			tree.CreateUserFirewallRuleWithNumber(ruleSetName, rule.RuleNumber, rule.toRules(ruleSetName))
+		}
+
+		for _, rule := range diff.RulesToUpdate {
+			// Clean up old address groups before applying the update; the old rule
+			// may have used a CSV (address group) that the new rule no longer needs.
+			if sourceGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), "address"); sourceGroupNode != nil {
+				sourceGroupNode.Delete()
+			}
+			if destGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), "address"); destGroupNode != nil {
+				destGroupNode.Delete()
+			}
 			if rule.SourceIp != "" && strings.ContainsAny(rule.SourceIp, IP_SPLIT) {
 				log.Debug(rule.toGroups(FIREWALL_RULE_SOURCE_GROUP_SUFFIX))
 				tree.SetGroupsCheckExisting("address", rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), rule.toGroups(FIREWALL_RULE_SOURCE_GROUP_SUFFIX))
@@ -743,6 +1075,22 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 			tree.CreateUserFirewallRuleWithNumber(ruleSetName, rule.RuleNumber, rule.toRules(ruleSetName))
 		}
 	}
+
+	for _, ruleSetName := range extraRuleSetNames {
+		for _, rule := range readCurrentUserRules(tree, ruleSetName) {
+			if isDefaultRule(strconv.Itoa(rule.RuleNumber)) {
+				continue
+			}
+			if sourceGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), "address"); sourceGroupNode != nil {
+				sourceGroupNode.Delete()
+			}
+			if destGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), "address"); destGroupNode != nil {
+				destGroupNode.Delete()
+			}
+			tree.Deletef("firewall name %s rule %v", ruleSetName, rule.RuleNumber)
+		}
+	}
+
 	tree.Apply(false)
 	return nil
 }

--- a/plugin/firewall.go
+++ b/plugin/firewall.go
@@ -1005,6 +1005,10 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 	currentRefs := make([]ethRuleSetRef, 0, len(cmd.Refs))
 	desiredRuleSetNames := make(map[string]struct{})
 	desiredByKey := make(map[string]desiredRuleSetCtx)
+	// Track rulesets whose VyOS firewall node exists but whose interface binding is absent.
+	// Config drift or a previous partial failure can leave the ruleset orphaned; these must
+	// be reattached even when no rule content has changed.
+	missingAttachments := make(map[string]bool)
 
 	for _, ref := range cmd.Refs {
 		nicName, err := utils.GetNicNameByMac(ref.Mac)
@@ -1015,6 +1019,10 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 
 		if tree.Getf("firewall name %s", ruleSetName) == nil {
 			continue
+		}
+
+		if tree.Getf("interfaces ethernet %s firewall %s name %s", nicName, ref.Forward, ruleSetName) == nil {
+			missingAttachments[fmt.Sprintf("%s//%s", ref.Mac, ref.Forward)] = true
 		}
 
 		currentActionType := ""
@@ -1049,7 +1057,8 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 	hasChanges := len(extraRuleSetNames) > 0
 	if !hasChanges {
 		for _, diff := range diffs {
-			if !diff.RuleSetExists || diff.ActionChanged || diff.LogChanged || len(diff.RulesToAdd) > 0 || len(diff.RulesToDelete) > 0 || len(diff.RulesToUpdate) > 0 {
+			key := fmt.Sprintf("%s//%s", diff.Mac, diff.Forward)
+			if !diff.RuleSetExists || diff.ActionChanged || diff.LogChanged || len(diff.RulesToAdd) > 0 || len(diff.RulesToDelete) > 0 || len(diff.RulesToUpdate) > 0 || missingAttachments[key] {
 				hasChanges = true
 				break
 			}
@@ -1076,6 +1085,11 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 
 		if diff.RuleSetExists && diff.ActionChanged {
 			tree.SetFirewalRuleSetAction(ruleSetName, diff.DesiredRuleSet.ActionType)
+			tree.AttachRuleSetOnInterface(nicName, diff.Forward, ruleSetName)
+		}
+
+		// Reattach if the interface binding was lost due to config drift or a previous partial failure.
+		if diff.RuleSetExists && !diff.ActionChanged && missingAttachments[key] {
 			tree.AttachRuleSetOnInterface(nicName, diff.Forward, ruleSetName)
 		}
 

--- a/plugin/firewall.go
+++ b/plugin/firewall.go
@@ -488,6 +488,38 @@ func diffUserRules(current, desired []ethRuleSetRef) []ruleSetDiff {
 	return diffs
 }
 
+func deleteExtraRuleSet(tree *server.VyosConfigTree, ruleSetName string) {
+	for _, rule := range readCurrentUserRules(tree, ruleSetName) {
+		if sourceGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), "address"); sourceGroupNode != nil {
+			sourceGroupNode.Delete()
+		}
+		if destGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), "address"); destGroupNode != nil {
+			destGroupNode.Delete()
+		}
+	}
+	detachRuleSetFromInterfaces(tree, ruleSetName)
+	tree.Deletef("firewall name %s", ruleSetName)
+}
+
+func detachRuleSetFromInterfaces(tree *server.VyosConfigTree, ruleSetName string) {
+	interfacesNode := tree.Get("interfaces ethernet")
+	if interfacesNode == nil {
+		return
+	}
+
+	for _, nicNode := range interfacesNode.Children() {
+		firewallNode := nicNode.Get("firewall")
+		if firewallNode == nil {
+			continue
+		}
+		for _, directionNode := range firewallNode.Children() {
+			if directionNode.GetChildrenValue("name") == ruleSetName {
+				tree.Deletef("interfaces ethernet %s firewall %s name %s", nicNode.Name(), directionNode.Name(), ruleSetName)
+			}
+		}
+	}
+}
+
 func getRuleNumber(t *server.VyosConfigNode) int {
 	number, err := strconv.Atoi(t.Name())
 	if err == nil {
@@ -1099,18 +1131,7 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 	}
 
 	for _, ruleSetName := range extraRuleSetNames {
-		for _, rule := range readCurrentUserRules(tree, ruleSetName) {
-			if isDefaultRule(strconv.Itoa(rule.RuleNumber)) {
-				continue
-			}
-			if sourceGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX), "address"); sourceGroupNode != nil {
-				sourceGroupNode.Delete()
-			}
-			if destGroupNode := tree.FindGroupByName(rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX), "address"); destGroupNode != nil {
-				destGroupNode.Delete()
-			}
-			tree.Deletef("firewall name %s rule %v", ruleSetName, rule.RuleNumber)
-		}
+		deleteExtraRuleSet(tree, ruleSetName)
 	}
 
 	tree.Apply(false)

--- a/plugin/firewall.go
+++ b/plugin/firewall.go
@@ -296,6 +296,10 @@ func readCurrentUserRules(tree *server.VyosConfigTree, ruleSetName string) []rul
 	return rules
 }
 
+// resolveRuleIPValue converts a rule address-group reference back to the API value.
+// Example: source group "eth5.in-1105-source" with members
+// ["10.130.145.0/24", "10.240.3.0/24"] becomes
+// "10.130.145.0/24,10.240.3.0/24". Plain IP/CIDR values are returned as-is.
 func resolveRuleIPValue(tree *server.VyosConfigTree, ruleSetName string, ruleNumber int, suffix, value string) string {
 	if !isLikelyRuleGroupName(ruleSetName, ruleNumber, suffix, value) {
 		return value
@@ -314,6 +318,10 @@ func resolveRuleIPValue(tree *server.VyosConfigTree, ruleSetName string, ruleNum
 	return strings.Join(members, IP_SPLIT)
 }
 
+// isLikelyRuleGroupName tells whether a rule field points to an address-group
+// instead of a literal IP/CIDR. For rule 1105 in eth5.in, the expected source
+// group name is "eth5.in-1105-source". Older configs may only preserve the
+// "-source"/"-dest" suffix, so the suffix fallback keeps them readable.
 func isLikelyRuleGroupName(ruleSetName string, ruleNumber int, suffix, value string) bool {
 	if value == "" || strings.Contains(value, "/") || strings.Contains(value, IP_SPLIT) {
 		return false
@@ -337,6 +345,10 @@ func isLikelyRuleGroupName(ruleSetName string, ruleNumber int, suffix, value str
 	return false
 }
 
+// normalizeCSV makes order-insensitive CSV fields comparable.
+// Example: "new,established,related" and "related,new,established" both become
+// "established,new,related"; the same normalization is used for address-group
+// members so an unchanged rule is not deleted/recreated during reconnect.
 func normalizeCSV(value string) string {
 	if strings.TrimSpace(value) == "" {
 		return ""
@@ -947,6 +959,12 @@ func applyUserRules(cmd *applyUserRuleCmd) interface{} {
 
 	tree := server.NewParserFromShowConfiguration().Tree
 
+	// Reconcile desired firewall refs with current VyOS config:
+	// 1. read current rules for each requested nic/direction;
+	// 2. diff current and desired rules by rule number and normalized content;
+	// 3. apply only add/update/delete operations, preserving unchanged rules.
+	// This avoids the old reconnect flow that deleted all user rules before
+	// recreating them, which could interrupt traffic when commit failed midway.
 	type desiredRuleSetCtx struct {
 		nicName     string
 		ruleSetName string

--- a/plugin/firewall_diff_test.go
+++ b/plugin/firewall_diff_test.go
@@ -1,0 +1,98 @@
+package plugin
+
+import "testing"
+
+func TestZSTAC83935DiffUserRulesKeepsUnchangedRules(t *testing.T) {
+	current := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
+		firewallDiffRule(1100, "10.130.145.0/24", "10.240.3.0/24"),
+		firewallDiffRule(1105, "10.130.145.0/24", "172.23.0.0/16"),
+		firewallDiffRule(2000, "", ""),
+	})}
+	desired := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
+		firewallDiffRule(1100, "10.130.145.0/24", "10.240.3.0/24"),
+		firewallDiffRule(1105, "10.130.145.0/24", "10.240.4.0/24"),
+		firewallDiffRule(2000, "", ""),
+	})}
+
+	diffs := diffUserRules(current, desired)
+	if len(diffs) != 1 {
+		t.Fatalf("expected one ruleset diff, got %d", len(diffs))
+	}
+	diff := diffs[0]
+	if !diff.RuleSetExists {
+		t.Fatal("expected existing ruleset to be reconciled in place")
+	}
+	if len(diff.RulesToDelete) != 0 {
+		t.Fatalf("unchanged reconnect must not delete existing rules, got %#v", diff.RulesToDelete)
+	}
+	if len(diff.RulesToAdd) != 0 {
+		t.Fatalf("unchanged reconnect must not recreate existing rules, got %#v", diff.RulesToAdd)
+	}
+	if len(diff.RulesToUpdate) != 1 || diff.RulesToUpdate[0].RuleNumber != 1105 {
+		t.Fatalf("expected only rule 1105 to be updated, got %#v", diff.RulesToUpdate)
+	}
+}
+
+func TestZSTAC83935DiffUserRulesDeletesOnlyStaleRules(t *testing.T) {
+	current := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
+		firewallDiffRule(1100, "10.130.145.0/24", "10.240.3.0/24"),
+		firewallDiffRule(1101, "10.130.145.0/24", "172.23.111.0/24"),
+	})}
+	desired := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
+		firewallDiffRule(1100, "10.130.145.0/24", "10.240.3.0/24"),
+		firewallDiffRule(1102, "10.130.145.0/24", "10.240.4.0/24"),
+	})}
+
+	diffs := diffUserRules(current, desired)
+	if len(diffs) != 1 {
+		t.Fatalf("expected one ruleset diff, got %d", len(diffs))
+	}
+	diff := diffs[0]
+	if len(diff.RulesToDelete) != 1 || diff.RulesToDelete[0].RuleNumber != 1101 {
+		t.Fatalf("expected only stale rule 1101 to be deleted, got %#v", diff.RulesToDelete)
+	}
+	if len(diff.RulesToAdd) != 1 || diff.RulesToAdd[0].RuleNumber != 1102 {
+		t.Fatalf("expected only missing rule 1102 to be added, got %#v", diff.RulesToAdd)
+	}
+	if len(diff.RulesToUpdate) != 0 {
+		t.Fatalf("unchanged rule must not be updated, got %#v", diff.RulesToUpdate)
+	}
+}
+
+func TestZSTAC83935RuleEqualNormalizesProtocolStateAndGroups(t *testing.T) {
+	current := firewallDiffRule(1100, "10.240.3.0/24,10.130.145.0/24", "172.23.0.0/16")
+	current.Protocol = ""
+	current.AllowStates = "new,established,related,invalid"
+
+	desired := firewallDiffRule(1100, "10.130.145.0/24,10.240.3.0/24", "172.23.0.0/16")
+	desired.Protocol = "ALL"
+	desired.AllowStates = "invalid,new,related,established"
+
+	if !current.Equal(desired) {
+		t.Fatalf("expected equivalent rule values to compare equal: current=%#v desired=%#v", current, desired)
+	}
+}
+
+func firewallDiffRef(mac, forward string, rules []ruleInfo) ethRuleSetRef {
+	return ethRuleSetRef{
+		Mac:     mac,
+		Forward: forward,
+		RuleSetInfo: ruleSetInfo{
+			Name:       "eth5.in",
+			ActionType: "reject",
+			Rules:      rules,
+		},
+	}
+}
+
+func firewallDiffRule(number int, sourceIP, destIP string) ruleInfo {
+	return ruleInfo{
+		Action:      "accept",
+		Protocol:    "all",
+		SourceIp:    sourceIP,
+		DestIp:      destIP,
+		AllowStates: "established,invalid,new,related",
+		RuleNumber:  number,
+		State:       RULEINFO_ENABLE,
+	}
+}

--- a/plugin/firewall_diff_test.go
+++ b/plugin/firewall_diff_test.go
@@ -1,6 +1,9 @@
 package plugin
 
-import "testing"
+import (
+	"testing"
+	"zstack-vyos/server"
+)
 
 func TestZSTAC83935DiffUserRulesKeepsUnchangedRules(t *testing.T) {
 	current := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
@@ -78,6 +81,70 @@ func TestZSTAC83935DiffUserRulesCreatesMissingRuleSet(t *testing.T) {
 	}
 	if len(diff.RulesToDelete) != 0 || len(diff.RulesToUpdate) != 0 {
 		t.Fatalf("missing ruleset must not delete or update rules, got deletes=%#v updates=%#v", diff.RulesToDelete, diff.RulesToUpdate)
+	}
+}
+
+func TestZSTAC83935DeleteExtraRuleSetRemovesNodeAndAttachments(t *testing.T) {
+	tree := server.NewParserFromConfiguration(`
+interfaces {
+    ethernet eth5 {
+        firewall {
+            in {
+                name eth5.in
+            }
+            out {
+                name eth5.out
+            }
+        }
+    }
+    ethernet eth6 {
+        firewall {
+            in {
+                name eth5.in
+            }
+        }
+    }
+}
+firewall {
+    group {
+        address-group eth5.in-1100-source {
+            address 10.130.145.0/24
+        }
+    }
+    name eth5.in {
+        default-action reject
+        enable-default-log
+        rule 1100 {
+            action accept
+            source {
+                group {
+                    address-group eth5.in-1100-source
+                }
+            }
+        }
+    }
+    name eth5.out {
+        default-action accept
+    }
+}
+`).Tree
+
+	deleteExtraRuleSet(tree, "eth5.in")
+
+	if tree.Get("firewall name eth5.in") != nil {
+		t.Fatal("expected extra firewall ruleset node to be deleted")
+	}
+	if tree.Get("interfaces ethernet eth5 firewall in name eth5.in") != nil {
+		t.Fatal("expected eth5 in binding to extra ruleset to be detached")
+	}
+	if tree.Get("interfaces ethernet eth6 firewall in name eth5.in") != nil {
+		t.Fatal("expected eth6 in binding to extra ruleset to be detached")
+	}
+	if tree.Get("firewall group address-group eth5.in-1100-source") != nil {
+		t.Fatal("expected address group owned by extra ruleset to be deleted")
+	}
+	if tree.Get("firewall name eth5.out") == nil || tree.Get("interfaces ethernet eth5 firewall out name eth5.out") == nil {
+		t.Fatal("unrelated firewall ruleset and binding must be kept")
 	}
 }
 

--- a/plugin/firewall_diff_test.go
+++ b/plugin/firewall_diff_test.go
@@ -2,7 +2,9 @@ package plugin
 
 import (
 	"testing"
-	"zstack-vyos/server"
+
+	"github.com/zstackio/zstack-vyos/server"
+	"github.com/zstackio/zstack-vyos/utils"
 )
 
 func TestZSTAC83935DiffUserRulesKeepsUnchangedRules(t *testing.T) {
@@ -183,5 +185,108 @@ func firewallDiffRule(number int, sourceIP, destIP string) ruleInfo {
 		AllowStates: "established,invalid,new,related",
 		RuleNumber:  number,
 		State:       RULEINFO_ENABLE,
+	}
+}
+
+// TestZSTAC83935DetachedRuleSetReattached verifies that a VyOS ruleset whose firewall node
+// exists but whose interface binding is absent is detected as requiring reattach.
+func TestZSTAC83935DetachedRuleSetReattached(t *testing.T) {
+	tree := server.NewParserFromConfiguration(`
+firewall {
+    name eth5.in {
+        default-action reject
+        rule 1100 {
+            action accept
+        }
+    }
+}
+`).Tree
+
+	// Firewall node exists but interface binding is intentionally absent.
+	if tree.Getf("firewall name %s", "eth5.in") == nil {
+		t.Fatal("test setup: expected firewall node to exist")
+	}
+	if tree.Getf("interfaces ethernet %s firewall %s name %s", "eth5", "in", "eth5.in") != nil {
+		t.Fatal("test setup: expected interface binding to be absent")
+	}
+
+	// Simulate the fix: detect missing binding and reattach.
+	tree.AttachRuleSetOnInterface("eth5", "in", "eth5.in")
+
+	if tree.Getf("interfaces ethernet %s firewall %s name %s", "eth5", "in", "eth5.in") == nil {
+		t.Fatal("expected interface binding to be present after reattach")
+	}
+}
+
+// TestZSTAC83935StaleIptablesChainFullyRemoved verifies that removing a stale iptables ruleset
+// also removes the hook rule, the default rule, and the chain itself — not just user rules.
+func TestZSTAC83935StaleIptablesChainFullyRemoved(t *testing.T) {
+	// Build an IpTables directly to avoid calling iptables-save (not available in unit-test env).
+	table := &utils.IpTables{Name: utils.FirewallTable, IpVersion: utils.IP_VERSION_4}
+	table.AddChain(utils.VYOS_FWD_ROOT_CHAIN)
+	table.AddChain("eth5.in") // stale
+	table.AddChain("eth6.in") // desired — must survive
+
+	// Hook rule dispatching to the stale chain.
+	staleHook := utils.NewIpTableRule(utils.VYOS_FWD_ROOT_CHAIN)
+	staleHook.SetAction("eth5.in")
+	staleHook.SetInNic("eth5")
+	table.AddIpTableRules([]*utils.IpTableRule{staleHook})
+
+	// Hook rule dispatching to the desired chain — must survive.
+	desiredHook := utils.NewIpTableRule(utils.VYOS_FWD_ROOT_CHAIN)
+	desiredHook.SetAction("eth6.in")
+	desiredHook.SetInNic("eth6")
+	table.AddIpTableRules([]*utils.IpTableRule{desiredHook})
+
+	// Default rule inside the stale chain.
+	defaultRule := utils.NewDefaultIpTableRule("eth5.in", utils.IPTABLES_RULENUMBER_MAX)
+	defaultRule.SetAction("REJECT")
+	table.AddIpTableRules([]*utils.IpTableRule{defaultRule})
+
+	// A user rule inside the stale chain.
+	userRule := utils.NewIpTableRule("eth5.in")
+	utils.SetFirewallRuleNumber(userRule, "eth5.in", 1100)
+	userRule.SetAction("RETURN")
+	table.AddIpTableRules([]*utils.IpTableRule{userRule})
+
+	// Apply the fix logic for extra rulesets.
+	extraRuleSetNames := []string{"eth5.in"}
+	for _, ruleSetName := range extraRuleSetNames {
+		var filteredRules []*utils.IpTableRule
+		for _, r := range table.Rules {
+			if r.GetChainName() == ruleSetName || r.GetAction() == ruleSetName {
+				continue
+			}
+			filteredRules = append(filteredRules, r)
+		}
+		table.Rules = filteredRules
+		table.DeleteChain(ruleSetName)
+	}
+
+	// Chain must be gone.
+	if table.CheckChain("eth5.in") {
+		t.Fatal("stale chain eth5.in must be deleted")
+	}
+
+	// No rule must reference the stale chain.
+	for _, r := range table.Rules {
+		if r.GetChainName() == "eth5.in" || r.GetAction() == "eth5.in" {
+			t.Fatalf("stale rule must be removed: chain=%q action=%q", r.GetChainName(), r.GetAction())
+		}
+	}
+
+	// Desired chain and its hook rule must survive.
+	if !table.CheckChain("eth6.in") {
+		t.Fatal("desired chain eth6.in must be kept")
+	}
+	desiredHookFound := false
+	for _, r := range table.Rules {
+		if r.GetChainName() == utils.VYOS_FWD_ROOT_CHAIN && r.GetAction() == "eth6.in" {
+			desiredHookFound = true
+		}
+	}
+	if !desiredHookFound {
+		t.Fatal("hook rule for desired chain eth6.in must be kept")
 	}
 }

--- a/plugin/firewall_diff_test.go
+++ b/plugin/firewall_diff_test.go
@@ -59,6 +59,28 @@ func TestZSTAC83935DiffUserRulesDeletesOnlyStaleRules(t *testing.T) {
 	}
 }
 
+func TestZSTAC83935DiffUserRulesCreatesMissingRuleSet(t *testing.T) {
+	desired := []ethRuleSetRef{firewallDiffRef("52:54:00:00:00:01", FIREWALL_DIRECTION_IN, []ruleInfo{
+		firewallDiffRule(1100, "10.130.145.0/24", "10.240.3.0/24"),
+		firewallDiffRule(1101, "10.130.145.0/24", "172.23.111.0/24"),
+	})}
+
+	diffs := diffUserRules(nil, desired)
+	if len(diffs) != 1 {
+		t.Fatalf("expected one ruleset diff, got %d", len(diffs))
+	}
+	diff := diffs[0]
+	if diff.RuleSetExists {
+		t.Fatal("missing ruleset must trigger create/attach path")
+	}
+	if len(diff.RulesToAdd) != 2 {
+		t.Fatalf("expected all desired rules to be added, got %#v", diff.RulesToAdd)
+	}
+	if len(diff.RulesToDelete) != 0 || len(diff.RulesToUpdate) != 0 {
+		t.Fatalf("missing ruleset must not delete or update rules, got deletes=%#v updates=%#v", diff.RulesToDelete, diff.RulesToUpdate)
+	}
+}
+
 func TestZSTAC83935RuleEqualNormalizesProtocolStateAndGroups(t *testing.T) {
 	current := firewallDiffRule(1100, "10.240.3.0/24,10.130.145.0/24", "172.23.0.0/16")
 	current.Protocol = ""

--- a/plugin/firewall_diff_test.go
+++ b/plugin/firewall_diff_test.go
@@ -222,7 +222,7 @@ firewall {
 // also removes the hook rule, the default rule, and the chain itself — not just user rules.
 func TestZSTAC83935StaleIptablesChainFullyRemoved(t *testing.T) {
 	// Build an IpTables directly to avoid calling iptables-save (not available in unit-test env).
-	table := &utils.IpTables{Name: utils.FirewallTable, IpVersion: utils.IP_VERSION_4}
+	table := &utils.IpTables{Name: utils.FirewallTable}
 	table.AddChain(utils.VYOS_FWD_ROOT_CHAIN)
 	table.AddChain("eth5.in") // stale
 	table.AddChain("eth6.in") // desired — must survive

--- a/plugin/firewall_iptables.go
+++ b/plugin/firewall_iptables.go
@@ -754,13 +754,27 @@ func applyUserRulesByIpTables(cmd *applyUserRuleCmd) error {
 				dstSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
 				deleteIpsets[dstSetName] = utils.NewIPSet(dstSetName, utils.IPSET_TYPE_HASH_NET)
 			}
-
-			deleteRules = append(deleteRules, getIpTableRuleFromRule(ruleSetName, rule))
 		}
 	}
 
 	table = removeIptablesRulesByFirewallRuleNumber(table, deleteRules, true)
 	table.AddIpTableRules(addRules)
+
+	// Fully purge stale chains: the partial-rule pass above only removes user rules tagged with
+	// FirewallRule; the default rule (SystemLastRule comment) and the hook rule in
+	// VYATTA_FW_IN_HOOK / VYATTA_FW_OUT_HOOK are not covered by that pass and must be removed
+	// explicitly so the chain stops enforcing its default action after removal.
+	for _, ruleSetName := range extraRuleSetNames {
+		var filteredRules []*utils.IpTableRule
+		for _, r := range table.Rules {
+			if r.GetChainName() == ruleSetName || r.GetAction() == ruleSetName {
+				continue
+			}
+			filteredRules = append(filteredRules, r)
+		}
+		table.Rules = filteredRules
+		table.DeleteChain(ruleSetName)
+	}
 
 	if err := table.Apply(); err != nil {
 		deleteIpsetMap(newIpsets)

--- a/plugin/firewall_iptables.go
+++ b/plugin/firewall_iptables.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -48,6 +50,7 @@ func getRuleSetFromIpTable(table *utils.IpTables) map[string]*ruleSetInfo {
 	   	-A eth2.in -m comment --comment "eth2.in-10000 default-action reject" -j REJECT --reject-with icmp-port-unreachable
 	*/
 	sets := make(map[string]*ruleSetInfo)
+	logRuleNumbers := make(map[string]map[int]bool)
 
 	for _, r := range table.Rules {
 		if isNicFilterChain(r.GetAction()) {
@@ -57,7 +60,14 @@ func getRuleSetFromIpTable(table *utils.IpTables) map[string]*ruleSetInfo {
 
 		if _, ok := sets[r.GetChainName()]; ok {
 			if r.GetAction() == utils.IPTABLES_ACTION_LOG {
-				sets[r.GetChainName()].EnableDefaultLog = true
+				if strings.Contains(r.GetComment(), utils.FirewallRule) {
+					if _, exists := logRuleNumbers[r.GetChainName()]; !exists {
+						logRuleNumbers[r.GetChainName()] = make(map[int]bool)
+					}
+					logRuleNumbers[r.GetChainName()][r.GetRuleNumber()] = true
+				} else {
+					sets[r.GetChainName()].EnableDefaultLog = true
+				}
 			} else if utils.IsDefaultRule(r) {
 				if r.GetAction() == utils.IPTABLES_ACTION_RETURN {
 					r.SetAction(utils.IPTABLES_ACTION_ACCEPT)
@@ -65,6 +75,19 @@ func getRuleSetFromIpTable(table *utils.IpTables) map[string]*ruleSetInfo {
 				sets[r.GetChainName()].ActionType = strings.ToLower(r.GetAction())
 			} else {
 				sets[r.GetChainName()].Rules = append(sets[r.GetChainName()].Rules, getRuleFromIpTableRule(r))
+			}
+		}
+	}
+
+	for chainName, ruleNumbers := range logRuleNumbers {
+		ruleSet, ok := sets[chainName]
+		if !ok {
+			continue
+		}
+
+		for i := range ruleSet.Rules {
+			if ruleNumbers[ruleSet.Rules[i].RuleNumber] {
+				ruleSet.Rules[i].EnableLog = true
 			}
 		}
 	}
@@ -80,7 +103,7 @@ func getRuleFromIpTableRule(r *utils.IpTableRule) ruleInfo {
 	}
 	rule.Action = strings.ToLower(r.GetAction())
 	if r.GetDstIpset() != "" {
-		rule.DestIp = r.GetDstIpset()
+		rule.DestIp = resolveIpsetToCSV(r.GetDstIpset())
 	} else if r.GetDstIp() != "" {
 		rule.DestIp = getRuleIpInfoFromIpTableRule(r.GetDstIp())
 	} else if r.GetDstIpRange() != "" {
@@ -88,14 +111,21 @@ func getRuleFromIpTableRule(r *utils.IpTableRule) ruleInfo {
 	}
 
 	if r.GetSrcIpset() != "" {
-		rule.SourceIp = r.GetSrcIpset()
+		rule.SourceIp = resolveIpsetToCSV(r.GetSrcIpset())
 	} else if r.GetSrcIp() != "" {
 		rule.SourceIp = getRuleIpInfoFromIpTableRule(r.GetSrcIp())
 	} else if r.GetSrcIpRange() != "" {
 		rule.SourceIp = getRuleIpInfoFromIpTableRule(r.GetSrcIpRange())
 	}
 
-	rule.Protocol = strings.ToUpper(r.GetProto())
+	if utils.IsEuler2203() && r.GetProto() == "ipv4" {
+		rule.Protocol = "ipencap"
+	} else {
+		rule.Protocol = strings.ToLower(r.GetProto())
+	}
+	if rule.Protocol == "" {
+		rule.Protocol = "all"
+	}
 	rule.SourcePort = r.GetSrcPort()
 	rule.DestPort = r.GetDstPort()
 	rule.AllowStates = strings.Join(r.GetState(), ",")
@@ -103,7 +133,6 @@ func getRuleFromIpTableRule(r *utils.IpTableRule) ruleInfo {
 	rule.Tcp = strings.Join(r.GetTcpFlags(), ",")
 	rule.Icmp = r.GetIcmpType()
 	rule.RuleNumber = r.GetRuleNumber()
-	rule.EnableLog = false
 	rule.State = "enable"
 	rule.IsDefault = isDefaultRule(fmt.Sprintf("%d", rule.RuleNumber))
 
@@ -115,6 +144,29 @@ func getRuleIpInfoFromIpTableRule(ip string) string {
 		return strings.Split(ip, "/")[0]
 	}
 	return ip
+}
+
+func resolveIpsetToCSV(ipsetName string) string {
+	ipset := utils.GetIpSet(ipsetName)
+	if ipset == nil || len(ipset.Member) == 0 {
+		return ipsetName
+	}
+
+	members := make([]string, 0, len(ipset.Member))
+	for _, member := range ipset.Member {
+		normalized := strings.TrimSpace(member)
+		if normalized == "" {
+			continue
+		}
+		members = append(members, getRuleIpInfoFromIpTableRule(normalized))
+	}
+
+	if len(members) == 0 {
+		return ipsetName
+	}
+
+	sort.Strings(members)
+	return strings.Join(members, IP_SPLIT)
 }
 
 func getIpTableRuleFromRule(ruleSetName string, r ruleInfo) *utils.IpTableRule {
@@ -494,75 +546,231 @@ ERROR_OUT:
 }
 
 func applyUserRulesByIpTables(cmd *applyUserRuleCmd) error {
-	var rules []*utils.IpTableRule
-	table := utils.NewIpTables(utils.FirewallTable)
-	newIpsets := make(map[string]*utils.IpSet)
+	readTable := utils.NewIpTables(utils.FirewallTable)
+	currentRuleSets := getRuleSetFromIpTable(readTable)
+	currentRefs := make([]ethRuleSetRef, 0, len(cmd.Refs))
+	desiredRuleSetNames := make(map[string]struct{}, len(cmd.Refs))
 
-	//if apply firewall Rule, delete all firewall rule first
-	table = deleteFirewallUserRule(table)
 	for _, ref := range cmd.Refs {
 		nicName, err := utils.GetNicNameByMac(ref.Mac)
-		utils.PanicOnError(err)
+		if err != nil {
+			return err
+		}
 		ruleSetName := buildRuleSetName(nicName, ref.Forward)
-
-		//create ruleSet and add last rule
-		table.AddChain(ruleSetName)
-		rule := utils.NewDefaultIpTableRule(ruleSetName, utils.IPTABLES_RULENUMBER_MAX)
-		rule.SetAction(getIptablesRuleActionFromRuleAction(ref.RuleSetInfo.ActionType))
-		rules = append(rules, rule)
-
-		/* attach ruleset to interface */
-		if ref.Forward == FIREWALL_DIRECTION_OUT {
-			rule := utils.NewIpTableRule(utils.VYOS_FWD_OUT_ROOT_CHAIN)
-			rule.SetAction(ruleSetName)
-			rule.SetOutNic(nicName)
-			rules = append(rules, rule)
-		} else if ref.Forward == FIREWALL_DIRECTION_IN {
-			rule := utils.NewIpTableRule(utils.VYOS_FWD_ROOT_CHAIN)
-			rule.SetAction(ruleSetName)
-			rule.SetOutNic(nicName)
-			rules = append(rules, rule)
-		} // local will not be updated
-
-		// if ruleInfo state is disable, not create iptables rule
-		ref.RuleSetInfo.Rules = deleteDisableRuleInfo(ref.RuleSetInfo.Rules)
-		for _, r := range ref.RuleSetInfo.Rules {
-			if r.SourceIp != "" && strings.ContainsAny(r.SourceIp, IP_SPLIT) {
-				srcSetName := r.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
-				newIpSet := createIpsetAndSetNet(srcSetName, r.SourceIp)
-				if newIpSet == nil {
-					goto ERROR_OUT
-				}
-				newIpsets[newIpSet.Name] = newIpSet
-			}
-			if r.DestIp != "" && strings.ContainsAny(r.DestIp, IP_SPLIT) {
-				dstSetName := r.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
-				newIpSet := createIpsetAndSetNet(dstSetName, r.DestIp)
-				if newIpSet == nil {
-					goto ERROR_OUT
-				}
-				newIpsets[newIpSet.Name] = newIpSet
-			}
-
-			rule := getIpTableRuleFromRule(ruleSetName, r)
-			if r.EnableLog {
-				rule1 := rule.Copy()
-				rule1.SetAction(utils.IPTABLES_ACTION_LOG)
-				rules = append(rules, rule1)
-			}
-			rules = append(rules, rule)
+		desiredRuleSetNames[ruleSetName] = struct{}{}
+		if currentRuleSet, ok := currentRuleSets[ruleSetName]; ok {
+			currentRefs = append(currentRefs, ethRuleSetRef{Mac: ref.Mac, Forward: ref.Forward, RuleSetInfo: *currentRuleSet})
 		}
 	}
 
-	table.AddIpTableRules(rules)
+	extraRuleSetNames := make([]string, 0)
+	for ruleSetName := range currentRuleSets {
+		if _, ok := desiredRuleSetNames[ruleSetName]; !ok {
+			extraRuleSetNames = append(extraRuleSetNames, ruleSetName)
+		}
+	}
+
+	diffs := diffUserRules(currentRefs, cmd.Refs)
+	hasChange := len(extraRuleSetNames) > 0
+	if !hasChange {
+		for _, diff := range diffs {
+			if !diff.RuleSetExists || diff.ActionChanged || diff.LogChanged || len(diff.RulesToAdd) > 0 || len(diff.RulesToDelete) > 0 || len(diff.RulesToUpdate) > 0 {
+				hasChange = true
+				break
+			}
+		}
+	}
+	if !hasChange {
+		return nil
+	}
+
+	// Create a fresh table for the write/Apply path. The readTable was mutated by
+	// getRuleSetFromIpTable which converts RETURN actions to ACCEPT for comparison;
+	// reusing it would write those mutations back via iptables-restore.
+	table := utils.NewIpTables(utils.FirewallTable)
+
+	var addRules []*utils.IpTableRule
+	var deleteRules []*utils.IpTableRule
+	deleteIpsets := make(map[string]*utils.IpSet)
+	newIpsets := make(map[string]*utils.IpSet)
+
+	for _, diff := range diffs {
+		nicName, err := utils.GetNicNameByMac(diff.Mac)
+		if err != nil {
+			return err
+		}
+		ruleSetName := buildRuleSetName(nicName, diff.Forward)
+
+		rulesToAdd := deleteDisableRuleInfo(diff.RulesToAdd)
+		rulesToUpdate := deleteDisableRuleInfo(diff.RulesToUpdate)
+
+		for _, rule := range rulesToAdd {
+			if rule.SourceIp != "" && strings.ContainsAny(rule.SourceIp, IP_SPLIT) {
+				srcSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
+				newIpSet := createIpsetAndSetNet(srcSetName, rule.SourceIp)
+				if newIpSet == nil {
+					goto ERROR_OUT
+				}
+				newIpsets[newIpSet.Name] = newIpSet
+			}
+			if rule.DestIp != "" && strings.ContainsAny(rule.DestIp, IP_SPLIT) {
+				dstSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
+				newIpSet := createIpsetAndSetNet(dstSetName, rule.DestIp)
+				if newIpSet == nil {
+					goto ERROR_OUT
+				}
+				newIpsets[newIpSet.Name] = newIpSet
+			}
+		}
+
+		for _, rule := range rulesToUpdate {
+			if rule.SourceIp != "" && strings.ContainsAny(rule.SourceIp, IP_SPLIT) {
+				srcSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
+				newIpSet := createIpsetAndSetNet(srcSetName, rule.SourceIp)
+				if newIpSet == nil {
+					goto ERROR_OUT
+				}
+				newIpsets[newIpSet.Name] = newIpSet
+			}
+			if rule.DestIp != "" && strings.ContainsAny(rule.DestIp, IP_SPLIT) {
+				dstSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
+				newIpSet := createIpsetAndSetNet(dstSetName, rule.DestIp)
+				if newIpSet == nil {
+					goto ERROR_OUT
+				}
+				newIpsets[newIpSet.Name] = newIpSet
+			}
+		}
+
+		if !diff.RuleSetExists {
+			table.AddChain(ruleSetName)
+			defaultRule := utils.NewDefaultIpTableRule(ruleSetName, utils.IPTABLES_RULENUMBER_MAX)
+			defaultRule.SetAction(getIptablesRuleActionFromRuleAction(diff.DesiredRuleSet.ActionType))
+			addRules = append(addRules, defaultRule)
+
+			if diff.Forward == FIREWALL_DIRECTION_OUT {
+				hookRule := utils.NewIpTableRule(utils.VYOS_FWD_OUT_ROOT_CHAIN)
+				hookRule.SetAction(ruleSetName)
+				hookRule.SetOutNic(nicName)
+				addRules = append(addRules, hookRule)
+			} else if diff.Forward == FIREWALL_DIRECTION_IN {
+				hookRule := utils.NewIpTableRule(utils.VYOS_FWD_ROOT_CHAIN)
+				hookRule.SetAction(ruleSetName)
+				hookRule.SetInNic(nicName)
+				addRules = append(addRules, hookRule)
+			}
+		}
+
+		if diff.RuleSetExists && diff.ActionChanged {
+			for _, r := range table.Rules {
+				if r.GetChainName() == ruleSetName && utils.IsDefaultRule(r) {
+					r.SetAction(getIptablesRuleActionFromRuleAction(diff.DesiredRuleSet.ActionType))
+				}
+			}
+		}
+
+		if diff.RuleSetExists && diff.LogChanged {
+			if diff.DesiredRuleSet.EnableDefaultLog {
+				logRule := utils.NewDefaultIpTableRule(ruleSetName, utils.IPTABLES_RULENUMBER_MAX)
+				logRule.SetAction(utils.IPTABLES_ACTION_LOG)
+				addRules = append(addRules, logRule)
+			} else {
+				for _, r := range table.Rules {
+					if r.GetChainName() == ruleSetName && r.GetAction() == utils.IPTABLES_ACTION_LOG && !strings.Contains(r.GetComment(), utils.FirewallRule) {
+						deleteRules = append(deleteRules, r)
+					}
+				}
+			}
+		}
+
+		for _, rule := range diff.RulesToDelete {
+			if rule.SourceIp != "" && (strings.ContainsAny(rule.SourceIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, rule.RuleNumber, FIREWALL_RULE_SOURCE_GROUP_SUFFIX, rule.SourceIp)) {
+				srcSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
+				deleteIpsets[srcSetName] = utils.NewIPSet(srcSetName, utils.IPSET_TYPE_HASH_NET)
+			}
+			if rule.DestIp != "" && (strings.ContainsAny(rule.DestIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, rule.RuleNumber, FIREWALL_RULE_DEST_GROUP_SUFFIX, rule.DestIp)) {
+				dstSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
+				deleteIpsets[dstSetName] = utils.NewIPSet(dstSetName, utils.IPSET_TYPE_HASH_NET)
+			}
+
+			deleteRules = append(deleteRules, getIpTableRuleFromRule(ruleSetName, rule))
+		}
+
+		for _, rule := range diff.RulesToUpdate {
+			if existingRuleSet, ok := currentRuleSets[ruleSetName]; ok {
+				for _, oldRule := range existingRuleSet.Rules {
+					if oldRule.RuleNumber != rule.RuleNumber {
+						continue
+					}
+
+					if oldRule.SourceIp != "" && (strings.ContainsAny(oldRule.SourceIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, oldRule.RuleNumber, FIREWALL_RULE_SOURCE_GROUP_SUFFIX, oldRule.SourceIp)) {
+						srcSetName := oldRule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
+						deleteIpsets[srcSetName] = utils.NewIPSet(srcSetName, utils.IPSET_TYPE_HASH_NET)
+					}
+					if oldRule.DestIp != "" && (strings.ContainsAny(oldRule.DestIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, oldRule.RuleNumber, FIREWALL_RULE_DEST_GROUP_SUFFIX, oldRule.DestIp)) {
+						dstSetName := oldRule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
+						deleteIpsets[dstSetName] = utils.NewIPSet(dstSetName, utils.IPSET_TYPE_HASH_NET)
+					}
+
+					deleteRules = append(deleteRules, getIpTableRuleFromRule(ruleSetName, oldRule))
+					break
+				}
+			}
+		}
+
+		for _, rule := range rulesToUpdate {
+			newRule := getIpTableRuleFromRule(ruleSetName, rule)
+			if rule.EnableLog {
+				logRule := newRule.Copy()
+				logRule.SetAction(utils.IPTABLES_ACTION_LOG)
+				addRules = append(addRules, logRule)
+			}
+			addRules = append(addRules, newRule)
+		}
+
+		for _, rule := range rulesToAdd {
+			newRule := getIpTableRuleFromRule(ruleSetName, rule)
+			if rule.EnableLog {
+				logRule := newRule.Copy()
+				logRule.SetAction(utils.IPTABLES_ACTION_LOG)
+				addRules = append(addRules, logRule)
+			}
+			addRules = append(addRules, newRule)
+		}
+	}
+
+	for _, ruleSetName := range extraRuleSetNames {
+		ruleSet := currentRuleSets[ruleSetName]
+		for _, rule := range ruleSet.Rules {
+			if isDefaultRule(strconv.Itoa(rule.RuleNumber)) {
+				continue
+			}
+
+			if rule.SourceIp != "" && (strings.ContainsAny(rule.SourceIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, rule.RuleNumber, FIREWALL_RULE_SOURCE_GROUP_SUFFIX, rule.SourceIp)) {
+				srcSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_SOURCE_GROUP_SUFFIX)
+				deleteIpsets[srcSetName] = utils.NewIPSet(srcSetName, utils.IPSET_TYPE_HASH_NET)
+			}
+			if rule.DestIp != "" && (strings.ContainsAny(rule.DestIp, IP_SPLIT) || isLikelyRuleGroupName(ruleSetName, rule.RuleNumber, FIREWALL_RULE_DEST_GROUP_SUFFIX, rule.DestIp)) {
+				dstSetName := rule.makeGroupName(ruleSetName, FIREWALL_RULE_DEST_GROUP_SUFFIX)
+				deleteIpsets[dstSetName] = utils.NewIPSet(dstSetName, utils.IPSET_TYPE_HASH_NET)
+			}
+
+			deleteRules = append(deleteRules, getIpTableRuleFromRule(ruleSetName, rule))
+		}
+	}
+
+	table = removeIptablesRulesByFirewallRuleNumber(table, deleteRules, true)
+	table.AddIpTableRules(addRules)
 
 	if err := table.Apply(); err != nil {
 		deleteIpsetMap(newIpsets)
 		return err
 	}
+
 	if err := swapIpsetAndDeleteTmp(newIpsets); err != nil {
 		return err
 	}
+	deleteIpsetMap(deleteIpsets)
 
 	return nil
 

--- a/utils/ipset.go
+++ b/utils/ipset.go
@@ -13,24 +13,28 @@ const (
 )
 
 /*
-  # sudo ipset list -o xml
+	# sudo ipset list -o xml
+
 <ipset name="eth3.in-1001-source">
-  <type>hash:ip</type>
-  <header>
-    <family>inet</family>
-    <hashsize>1024</hashsize>
-    <maxelem>65536</maxelem>
-    <memsize>344</memsize>
-    <references>0</references>
-  </header>
-  <members>
-    <member>1.1.1.1</member>
-    <member>2.2.2.1</member>
-    <member>1.1.1.2</member>
-  </members>
+
+	<type>hash:ip</type>
+	<header>
+	  <family>inet</family>
+	  <hashsize>1024</hashsize>
+	  <maxelem>65536</maxelem>
+	  <memsize>344</memsize>
+	  <references>0</references>
+	</header>
+	<members>
+	  <member>1.1.1.1</member>
+	  <member>2.2.2.1</member>
+	  <member>1.1.1.2</member>
+	</members>
+
 </ipset>
 <ipset name="eth3.in-1003-source">
-  <type>hash:ip</type>
+
+	<type>hash:ip</type>
 */
 type IpSetList struct {
 	XMLName xml.Name `xml:"ipsets"`
@@ -62,6 +66,21 @@ func GetCurrentIpSet() ([]*IpSet, error) {
 	}
 
 	return ipSets.Ipsets, nil
+}
+
+func GetIpSet(name string) *IpSet {
+	ipsets, err := GetCurrentIpSet()
+	if err != nil {
+		return nil
+	}
+
+	for _, ipset := range ipsets {
+		if ipset.Name == name {
+			return ipset
+		}
+	}
+
+	return nil
 }
 
 func NewIPSet(name, ipsetType string) *IpSet {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,8 +28,8 @@ func formatVersion(versionNo string) int {
 }
 
 // CompareVersion
-//*   Compare two version numbers
-//*   version string format: x.y.z, ( 0 <= x, y, y < 100)
+// *   Compare two version numbers
+// *   version string format: x.y.z, ( 0 <= x, y, y < 100)
 func CompareVersion(version1, version2 string) (error, int) {
 	version1No, version2No := formatVersion(version1), formatVersion(version2)
 	if version1No == -1 || version2No == -1 {
@@ -40,8 +40,8 @@ func CompareVersion(version1, version2 string) (error, int) {
 }
 
 // ValidVersionString
-//*   Compare two version numbers
-//*   version string format: x.y.z, ( 0 <= x, y, y < 100)
+// *   Compare two version numbers
+// *   version string format: x.y.z, ( 0 <= x, y, y < 100)
 func ValidVersionString(version string) bool {
 	versionList := strings.Split(version, ".")
 	if len(versionList) != 3 {
@@ -54,6 +54,19 @@ func ValidVersionString(version string) bool {
 		}
 	}
 	return true
+}
+
+func IsEuler2203() bool {
+	if ok, err := PathExists("/etc/system-release"); err != nil || !ok {
+		return false
+	}
+
+	version, err := ReadLine("/etc/system-release")
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(version, "openEuler release 22.03")
 }
 
 func IsVYOS() bool {


### PR DESCRIPTION
Backport from ZSTAC-83935 / zstack-vyos MR1092. Cherry-picked source commits 4f592249, 26a71a79, dae1bee0, c9ef1956, 983f2967 and added a 4.8 compatibility commit for ipset/Euler helpers. Validation: git diff --check passed; go test -c ./plugin passed; go test runtime is blocked by local /home/zstack/zvr dhcp init dependency.

sync from gitlab !1135