### PR TITLE
<fix>[snat]: ZSTAC-86067 skip slb private snat

### DIFF
--- a/plugin/configure_nic.go
+++ b/plugin/configure_nic.go
@@ -245,7 +245,7 @@ func configureNicFirewall(nics []utils.NicInfo) {
 				err := configureLBFirewallRuleByIpTables(nicname)
 				utils.PanicOnError(err)
 
-				err = utils.AddSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
+				err = utils.SyncSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
 				utils.PanicOnError(err)
 			}
 		}
@@ -313,16 +313,7 @@ func configureNicFirewall(nics []utils.NicInfo) {
 				log.Debug("start configure LB firewall rule")
 				configureLBFirewallRuleByVyos(tree, nicname)
 
-				// add private SNAT rule
-				nicNo, _ := utils.GetNicNumber(nicname)
-				ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
-				address, _ := utils.GetNetworkNumber(nic.Ip, nic.Netmask)
-				tree.SetSnatWithRuleNumber(ruleNo,
-					fmt.Sprintf("outbound-interface %s", nicname),
-					fmt.Sprintf("source address %s", address),
-					"destination address !224.0.0.0/8",
-					fmt.Sprintf("translation address %s", nic.Ip),
-				)
+				SyncPrivateNicSnatRuleByVyos(tree, nicname, nic.Ip, nic.Netmask)
 			}
 		}
 
@@ -520,22 +511,7 @@ func RemoveNic(cmd *ConfigureNicCmd) interface{} {
 				err = utils.RemoveSnatRuleForPrivateNic(nicname, nic.Ip, nic.Netmask)
 				utils.PanicOnError(err)
 			} else {
-				// delete private SNAT rule (VyOS config) added during configureNicFirewall
-				address, _ := utils.GetNetworkNumber(nic.Ip, nic.Netmask)
-				rules := tree.Get("nat source rule")
-				if rules != nil {
-					for _, r := range rules.Children() {
-						outIf := r.Get("outbound-interface")
-						sAddr := r.Get("source address")
-						tAddr := r.Get("translation address")
-						if outIf != nil && outIf.Value() == nicname &&
-							sAddr != nil && sAddr.Value() == address &&
-							tAddr != nil && tAddr.Value() == nic.Ip {
-							r.Delete()
-							break
-						}
-					}
-				}
+				RemovePrivateNicSnatRuleByVyos(tree, nicname, nic.Ip, nic.Netmask)
 
 				tree.Deletef("firewall name %s.in", nicname)
 				tree.Deletef("firewall name %s.local", nicname)

--- a/plugin/snat.go
+++ b/plugin/snat.go
@@ -106,6 +106,165 @@ func getNicSNATRuleNumberByConfig(tree *server.VyosConfigTree, snat SnatInfo, ch
 	return ruleId3, ruleId4
 }
 
+func SyncPrivateNicSnatRuleByVyos(tree *server.VyosConfigTree, nicName, ip, netmask string) bool {
+	if utils.ShouldConfigurePrivateNicSnat(ip) {
+		return addPrivateNicSnatRuleByVyos(tree, nicName, ip, netmask)
+	}
+
+	return RemovePrivateNicSnatRuleByVyos(tree, nicName, ip, netmask)
+}
+
+func addPrivateNicSnatRuleByVyos(tree *server.VyosConfigTree, nicName, ip, netmask string) bool {
+	if !utils.ShouldConfigurePrivateNicSnat(ip) {
+		return false
+	}
+
+	if privateNicSnatRuleExists(tree, nicName, ip, netmask) {
+		return false
+	}
+
+	nicNo, err := utils.GetNicNumber(nicName)
+	utils.PanicOnError(err)
+	ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
+	address, err := utils.GetNetworkNumber(ip, netmask)
+	utils.PanicOnError(err)
+	tree.SetSnatWithRuleNumber(ruleNo,
+		fmt.Sprintf("outbound-interface %s", nicName),
+		fmt.Sprintf("source address %s", address),
+		"destination address !224.0.0.0/8",
+		fmt.Sprintf("translation address %s", ip),
+	)
+	return true
+}
+
+func privateNicSnatRuleExists(tree *server.VyosConfigTree, nicName, ip, netmask string) bool {
+	if !utils.IsIpv4Address(ip) {
+		return false
+	}
+
+	address, err := utils.GetNetworkNumber(ip, netmask)
+	utils.PanicOnError(err)
+	rules := tree.Get("nat source rule")
+	if rules == nil {
+		return false
+	}
+
+	for _, r := range rules.Children() {
+		outIf := r.Get("outbound-interface")
+		sAddr := r.Get("source address")
+		tAddr := r.Get("translation address")
+		if outIf != nil && outIf.Value() == nicName &&
+			sAddr != nil && sAddr.Value() == address &&
+			tAddr != nil && tAddr.Value() == ip {
+			return true
+		}
+	}
+
+	return false
+}
+
+func RemovePrivateNicSnatRuleByVyos(tree *server.VyosConfigTree, nicName, ip, netmask string) bool {
+	if !utils.IsIpv4Address(ip) {
+		return false
+	}
+
+	address, err := utils.GetNetworkNumber(ip, netmask)
+	utils.PanicOnError(err)
+	rules := tree.Get("nat source rule")
+	if rules == nil {
+		return false
+	}
+
+	updated := false
+	for _, r := range rules.Children() {
+		outIf := r.Get("outbound-interface")
+		sAddr := r.Get("source address")
+		tAddr := r.Get("translation address")
+		if outIf != nil && outIf.Value() == nicName &&
+			sAddr != nil && sAddr.Value() == address &&
+			tAddr != nil && tAddr.Value() == ip {
+			r.Delete()
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+func defaultPrivateNicSnatRuleMatches(r *server.VyosConfigNode, privateNicNames map[string]struct{}) bool {
+	outIf := r.Get("outbound-interface")
+	dstAddr := r.Get("destination address")
+	tAddr := r.Get("translation address")
+	if outIf == nil || dstAddr == nil || tAddr == nil {
+		return false
+	}
+
+	_, ok := privateNicNames[outIf.Value()]
+	return ok && dstAddr.Value() == "!224.0.0.0/8"
+}
+
+func RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree *server.VyosConfigTree) bool {
+	if !utils.IsSLB() {
+		return false
+	}
+
+	privateNicNames := make(map[string]struct{})
+	for _, nic := range utils.GetBootStrapPrivateNicInfo() {
+		if !utils.IsIpv4Address(nic.Ip) {
+			continue
+		}
+		privateNicNames[nic.Name] = struct{}{}
+	}
+	if len(privateNicNames) == 0 {
+		return false
+	}
+
+	rules := tree.Get("nat source rule")
+	if rules == nil {
+		return false
+	}
+
+	updated := false
+	for _, r := range rules.Children() {
+		if defaultPrivateNicSnatRuleMatches(r, privateNicNames) {
+			r.Delete()
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+func cleanupSlbPrivateNicSnatRulesByIptables() {
+	if !utils.IsSLB() {
+		return
+	}
+
+	err := utils.RemoveAllPrivateNicSnatRules()
+	utils.PanicOnError(err)
+}
+
+func cleanupSlbPrivateNicSnatRulesByVyos() {
+	if !utils.IsSLB() {
+		return
+	}
+
+	tree := server.NewParserFromShowConfiguration().Tree
+	if RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree) {
+		tree.Apply(false)
+	}
+}
+
+func getAvailablePublicNicSNATRuleNumber(tree *server.VyosConfigTree, nicNumber int) int {
+	pubNicRuleNo, _ := utils.GetPublicNicSNATRuleNumber(nicNumber)
+	for j := 1; ; j++ {
+		if tree.Getf("nat source rule %v", pubNicRuleNo) == nil {
+			return pubNicRuleNo
+		}
+		pubNicRuleNo, _ = utils.GetPublicNicSNATRuleNumber(nicNumber + j)
+	}
+}
+
 // Deprecated
 func setSnatHandler(ctx *server.CommandContext) interface{} {
 	cmd := &SetSnatCmd{}
@@ -140,14 +299,16 @@ func SetSnat(cmd *SetSnatCmd) interface{} {
 		err := table.Apply()
 		utils.PanicOnError(err)
 
-		utils.AddSnatRuleForPrivateNic(inNic, s.PrivateNicIp, s.SnatNetmask)
+		err = utils.SyncSnatRuleForPrivateNic(inNic, s.PrivateNicIp, s.SnatNetmask)
+		utils.PanicOnError(err)
 	} else {
 		// make source nat rule as the latest rule
 		// in case there are EIP rules
 		tree := server.NewParserFromShowConfiguration().Tree
-		pubNicRuleNo, _ := utils.GetPublicNicSNATRuleNumber(nicNumber)
+		pubNicRuleNo, _ := getNicSNATRuleNumberByConfig(tree, s, false)
 		setted := false
-		if !hasRuleNumberForAddress(tree, address, pubNicRuleNo) {
+		if pubNicRuleNo == 0 {
+			pubNicRuleNo = getAvailablePublicNicSNATRuleNumber(tree, nicNumber)
 			tree.SetSnatWithRuleNumber(pubNicRuleNo,
 				fmt.Sprintf("outbound-interface %s", outNic),
 				fmt.Sprintf("source address %v", address),
@@ -208,15 +369,6 @@ func RemoveSnat(cmd *RemoveSnatCmd) interface{} {
 	}
 
 	return nil
-}
-
-func hasRuleNumberForAddress(tree *server.VyosConfigTree, address string, ruleNo int) bool {
-	rs := tree.Get(fmt.Sprintf("nat source rule %v", ruleNo))
-	if rs == nil {
-		return false
-	}
-
-	return true
 }
 
 func setSnatStateByIptables(Snats []SnatInfo, state bool) {
@@ -300,17 +452,8 @@ func applySnatRules(Snats []SnatInfo, state bool) bool {
 
 		pubNicRuleNo, _ := getNicSNATRuleNumberByConfig(tree, s, false)
 		if s.State == true {
-			newPubNicRuleNo, _ := utils.GetPublicNicSNATRuleNumber(nicNumber)
-			for j := 1; ; j++ {
-				if tree.Getf("nat source rule %v", newPubNicRuleNo) == nil {
-					break
-				} else {
-					newPubNicRuleNo, _ = utils.GetPublicNicSNATRuleNumber(nicNumber + j)
-				}
-			}
-
 			if pubNicRuleNo == 0 {
-				pubNicRuleNo = newPubNicRuleNo
+				pubNicRuleNo = getAvailablePublicNicSNATRuleNumber(tree, nicNumber)
 				pubRule := tree.Getf("nat source rule %v", pubNicRuleNo)
 				if pubRule == nil {
 					tree.SetSnatWithRuleNumber(pubNicRuleNo,
@@ -382,6 +525,7 @@ func syncSnatHandler(ctx *server.CommandContext) interface{} {
 func SyncSnat(cmd *SyncSnatCmd) interface{} {
 	if utils.IsSkipVyosIptables() {
 		syncSnatByIptables(cmd.Snats, cmd.Enable)
+		cleanupSlbPrivateNicSnatRulesByIptables()
 	} else {
 		update := applySnatRules(cmd.Snats, cmd.Enable)
 		if update && len(cmd.Snats) > 0 {
@@ -390,6 +534,11 @@ func SyncSnat(cmd *SyncSnatCmd) interface{} {
 				PortStart: 0, PortEnd: 0}
 			t.CleanConnTrackConnection()
 		}
+		cleanupSlbPrivateNicSnatRulesByVyos()
+	}
+
+	if utils.IsSLB() {
+		return nil
 	}
 
 	// ensure private SNAT rules exist when enabled:
@@ -398,7 +547,6 @@ func SyncSnat(cmd *SyncSnatCmd) interface{} {
 		nicName string
 		nicIp   string
 		netmask string
-		addr    string
 	}
 	privates := make(map[string]priInfo) // key: private MAC
 	for _, s := range cmd.Snats {
@@ -411,55 +559,23 @@ func SyncSnat(cmd *SyncSnatCmd) interface{} {
 		if err != nil || inNic == "" {
 			continue
 		}
-		address, err := utils.GetNetworkNumber(s.PrivateNicIp, s.SnatNetmask)
-		if err != nil || address == "" {
-			continue
-		}
 		privates[s.PrivateNicMac] = priInfo{
 			nicName: inNic,
 			nicIp:   s.PrivateNicIp,
 			netmask: s.SnatNetmask,
-			addr:    address,
 		}
 	}
 
 	// add missing private SNAT rules per mode
 	if utils.IsSkipVyosIptables() {
 		for _, p := range privates {
-			_ = utils.AddSnatRuleForPrivateNic(p.nicName, p.nicIp, p.netmask)
+			_ = utils.SyncSnatRuleForPrivateNic(p.nicName, p.nicIp, p.netmask)
 		}
 	} else {
 		tree := server.NewParserFromShowConfiguration().Tree
 		updated := false
 		for _, p := range privates {
-			nicNo, err := utils.GetNicNumber(p.nicName)
-			if err != nil {
-				continue
-			}
-			ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
-			// scan existing nat source rules to see if one matches fields:
-			rules := tree.Get("nat source rule")
-			exists := false
-			if rules != nil {
-				for _, r := range rules.Children() {
-					outIf := r.Get("outbound-interface")
-					sAddr := r.Get("source address")
-					tAddr := r.Get("translation address")
-					if outIf != nil && outIf.Value() == p.nicName &&
-						sAddr != nil && sAddr.Value() == p.addr &&
-						tAddr != nil && tAddr.Value() == p.nicIp {
-						exists = true
-						break
-					}
-				}
-			}
-			if !exists {
-				tree.SetSnatWithRuleNumber(ruleNo,
-					fmt.Sprintf("outbound-interface %s", p.nicName),
-					fmt.Sprintf("source address %s", p.addr),
-					"destination address !224.0.0.0/8",
-					fmt.Sprintf("translation address %s", p.nicIp),
-				)
+			if SyncPrivateNicSnatRuleByVyos(tree, p.nicName, p.nicIp, p.netmask) {
 				updated = true
 			}
 		}

--- a/plugin/snat.go
+++ b/plugin/snat.go
@@ -191,7 +191,7 @@ func RemovePrivateNicSnatRuleByVyos(tree *server.VyosConfigTree, nicName, ip, ne
 	return updated
 }
 
-func defaultPrivateNicSnatRuleMatches(r *server.VyosConfigNode, privateNicNames map[string]struct{}) bool {
+func defaultPrivateNicSnatRuleMatches(r *server.VyosConfigNode, privateNicIPs map[string]string) bool {
 	outIf := r.Get("outbound-interface")
 	dstAddr := r.Get("destination address")
 	tAddr := r.Get("translation address")
@@ -199,8 +199,8 @@ func defaultPrivateNicSnatRuleMatches(r *server.VyosConfigNode, privateNicNames 
 		return false
 	}
 
-	_, ok := privateNicNames[outIf.Value()]
-	return ok && dstAddr.Value() == "!224.0.0.0/8"
+	expectedIP, ok := privateNicIPs[outIf.Value()]
+	return ok && dstAddr.Value() == "!224.0.0.0/8" && tAddr.Value() == expectedIP
 }
 
 func RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree *server.VyosConfigTree) bool {
@@ -208,14 +208,14 @@ func RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree *server.VyosConfigTree) bool
 		return false
 	}
 
-	privateNicNames := make(map[string]struct{})
+	privateNicIPs := make(map[string]string)
 	for _, nic := range utils.GetBootStrapPrivateNicInfo() {
 		if !utils.IsIpv4Address(nic.Ip) {
 			continue
 		}
-		privateNicNames[nic.Name] = struct{}{}
+		privateNicIPs[nic.Name] = nic.Ip
 	}
-	if len(privateNicNames) == 0 {
+	if len(privateNicIPs) == 0 {
 		return false
 	}
 
@@ -226,7 +226,7 @@ func RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree *server.VyosConfigTree) bool
 
 	updated := false
 	for _, r := range rules.Children() {
-		if defaultPrivateNicSnatRuleMatches(r, privateNicNames) {
+		if defaultPrivateNicSnatRuleMatches(r, privateNicIPs) {
 			r.Delete()
 			updated = true
 		}
@@ -569,7 +569,8 @@ func SyncSnat(cmd *SyncSnatCmd) interface{} {
 	// add missing private SNAT rules per mode
 	if utils.IsSkipVyosIptables() {
 		for _, p := range privates {
-			_ = utils.SyncSnatRuleForPrivateNic(p.nicName, p.nicIp, p.netmask)
+			err := utils.SyncSnatRuleForPrivateNic(p.nicName, p.nicIp, p.netmask)
+			utils.PanicOnError(err)
 		}
 	} else {
 		tree := server.NewParserFromShowConfiguration().Tree

--- a/plugin/snat_private_test.go
+++ b/plugin/snat_private_test.go
@@ -1,0 +1,135 @@
+package plugin
+
+import (
+	"testing"
+
+	"zstack-vyos/server"
+	"zstack-vyos/utils"
+)
+
+func TestRemoveSlbDefaultPrivateNicSnatRulesByVyos(t *testing.T) {
+	originalBootstrapInfo := utils.BootstrapInfo
+	defer func() {
+		utils.BootstrapInfo = originalBootstrapInfo
+	}()
+
+	utils.BootstrapInfo = map[string]interface{}{
+		"applianceVmSubType": utils.APPLIANCETYPE_SLB,
+		"additionalNics": []interface{}{
+			map[string]interface{}{
+				"category":   utils.NIC_TYPE_PRIVATE,
+				"deviceName": "eth1",
+				"ip":         "192.168.10.1",
+				"netmask":    "255.255.255.0",
+			},
+			map[string]interface{}{
+				"category":     utils.NIC_TYPE_PRIVATE,
+				"deviceName":   "eth2",
+				"ip6":          "2001:db8::1",
+				"gateway6":     "2001:db8::ff",
+				"prefixLength": 64,
+			},
+			map[string]interface{}{
+				"category":   utils.NIC_TYPE_PUBLIC,
+				"deviceName": "eth0",
+				"ip":         "172.20.10.2",
+				"netmask":    "255.255.255.0",
+			},
+		},
+	}
+
+	tree := server.NewParserFromConfiguration("").Tree
+	tree.SetSnatWithRuleNumber(6000,
+		"outbound-interface eth1",
+		"source address 192.168.10.0/24",
+		"destination address !224.0.0.0/8",
+		"translation address 192.168.10.1",
+	)
+	tree.SetSnatWithRuleNumber(7000,
+		"outbound-interface eth0",
+		"source address 192.168.10.0/24",
+		"destination address !224.0.0.0/8",
+		"translation address 172.20.10.2",
+	)
+	tree.SetSnatWithRuleNumber(6500,
+		"description eip-gw-snat",
+		"outbound-interface eth1",
+		"destination address 192.168.10.100",
+		"translation address 192.168.10.1",
+	)
+	tree.SetSnatWithRuleNumber(6600,
+		"outbound-interface eth2",
+		"source address 2001:db8::/64",
+		"destination address !224.0.0.0/8",
+		"translation address 2001:db8::1",
+	)
+	tree.SetSnatWithRuleNumber(100,
+		"description ipsec-exclude",
+		"outbound-interface eth1",
+		"destination address 10.10.0.0/24",
+		"exclude",
+	)
+
+	if !RemoveSlbDefaultPrivateNicSnatRulesByVyos(tree) {
+		t.Fatal("expected SLB private-local SNAT rule to be removed")
+	}
+	if tree.Get("nat source rule 6000") != nil {
+		t.Fatal("private-local SNAT rule was not removed")
+	}
+	if tree.Get("nat source rule 7000") == nil {
+		t.Fatal("public SNAT rule should not be removed")
+	}
+	if tree.Get("nat source rule 6500") == nil {
+		t.Fatal("EIP gateway SNAT rule should not be removed")
+	}
+	if tree.Get("nat source rule 6600") == nil {
+		t.Fatal("IPv6 private nic rule should not be removed by IPv4 SNAT cleanup")
+	}
+	if tree.Get("nat source rule 100") == nil {
+		t.Fatal("IPsec exclude rule should not be removed")
+	}
+}
+
+func TestAddPrivateNicSnatRuleByVyosSkipsUnsupportedPrivateSnat(t *testing.T) {
+	originalBootstrapInfo := utils.BootstrapInfo
+	defer func() {
+		utils.BootstrapInfo = originalBootstrapInfo
+	}()
+
+	utils.BootstrapInfo = map[string]interface{}{}
+	tree := server.NewParserFromConfiguration("").Tree
+	if addPrivateNicSnatRuleByVyos(tree, "eth1", "2001:db8::1", "64") {
+		t.Fatal("IPv6 private SNAT rule should not be added")
+	}
+	if tree.Get("nat source rule") != nil {
+		t.Fatal("IPv6 private SNAT should not create nat source rules")
+	}
+
+	utils.BootstrapInfo = map[string]interface{}{
+		"applianceVmSubType": utils.APPLIANCETYPE_SLB,
+	}
+	if addPrivateNicSnatRuleByVyos(tree, "eth1", "192.168.10.1", "255.255.255.0") {
+		t.Fatal("SLB private SNAT rule should not be added")
+	}
+	if tree.Get("nat source rule") != nil {
+		t.Fatal("SLB private SNAT should not create nat source rules")
+	}
+}
+
+func TestGetAvailablePublicNicSNATRuleNumberSkipsOccupiedRules(t *testing.T) {
+	tree := server.NewParserFromConfiguration("").Tree
+
+	defaultRuleNo, _ := utils.GetPublicNicSNATRuleNumber(1)
+	nextRuleNo, _ := utils.GetPublicNicSNATRuleNumber(2)
+	tree.SetSnatWithRuleNumber(defaultRuleNo,
+		"outbound-interface eth0",
+		"source address 192.168.10.0/24",
+		"destination address !224.0.0.0/8",
+		"translation address 172.20.10.2",
+	)
+
+	ruleNo := getAvailablePublicNicSNATRuleNumber(tree, 1)
+	if ruleNo != nextRuleNo {
+		t.Fatalf("expected next available public SNAT rule %d, got %d", nextRuleNo, ruleNo)
+	}
+}

--- a/plugin/snat_private_test.go
+++ b/plugin/snat_private_test.go
@@ -57,6 +57,13 @@ func TestRemoveSlbDefaultPrivateNicSnatRulesByVyos(t *testing.T) {
 		"destination address 192.168.10.100",
 		"translation address 192.168.10.1",
 	)
+	tree.SetSnatWithRuleNumber(6550,
+		"description custom-private-snat",
+		"outbound-interface eth1",
+		"source address 192.168.10.0/24",
+		"destination address !224.0.0.0/8",
+		"translation address 192.168.10.254",
+	)
 	tree.SetSnatWithRuleNumber(6600,
 		"outbound-interface eth2",
 		"source address 2001:db8::/64",
@@ -81,6 +88,9 @@ func TestRemoveSlbDefaultPrivateNicSnatRulesByVyos(t *testing.T) {
 	}
 	if tree.Get("nat source rule 6500") == nil {
 		t.Fatal("EIP gateway SNAT rule should not be removed")
+	}
+	if tree.Get("nat source rule 6550") == nil {
+		t.Fatal("custom private SNAT rule with a different translation address should not be removed")
 	}
 	if tree.Get("nat source rule 6600") == nil {
 		t.Fatal("IPv6 private nic rule should not be removed by IPv4 SNAT cleanup")

--- a/utils/bootStrapInfo.go
+++ b/utils/bootStrapInfo.go
@@ -290,6 +290,71 @@ func GetBootStrapNicInfo() map[string]Nic {
 	return bootstrapNics
 }
 
+func GetBootStrapPrivateNicInfo() []Nic {
+	nics := make([]Nic, 0)
+	additionalNics, ok := BootstrapInfo["additionalNics"]
+	if !ok {
+		return nics
+	}
+
+	appendNic := func(nic map[string]interface{}) {
+		category, _ := nic["category"].(string)
+		ip, _ := nic["ip"].(string)
+		ip6, _ := nic["ip6"].(string)
+		if category != NIC_TYPE_PRIVATE || (ip == "" && ip6 == "") {
+			return
+		}
+
+		name, _ := nic["deviceName"].(string)
+		mac, _ := nic["mac"].(string)
+		if mac != "" {
+			if nicName, err := GetNicNameByMac(mac); err == nil && nicName != "" {
+				name = nicName
+			}
+		}
+		if name == "" {
+			return
+		}
+
+		netmask, _ := nic["netmask"].(string)
+		gateway, _ := nic["gateway"].(string)
+		gateway6, _ := nic["gateway6"].(string)
+		prefixLength := 0
+		switch v := nic["prefixLength"].(type) {
+		case int:
+			prefixLength = v
+		case float64:
+			prefixLength = int(v)
+		}
+		nics = append(nics, Nic{
+			Name:         name,
+			Mac:          mac,
+			Ip:           ip,
+			Ip6:          ip6,
+			Gateway:      gateway,
+			Gateway6:     gateway6,
+			Netmask:      netmask,
+			PrefixLength: prefixLength,
+			Catatory:     category,
+		})
+	}
+
+	switch otherNics := additionalNics.(type) {
+	case []interface{}:
+		for _, n := range otherNics {
+			if nic, ok := n.(map[string]interface{}); ok {
+				appendNic(nic)
+			}
+		}
+	case []map[string]interface{}:
+		for _, nic := range otherNics {
+			appendNic(nic)
+		}
+	}
+
+	return nics
+}
+
 func SetHaStatus(status string) {
 	BootstrapInfo["haStatus"] = status
 }

--- a/utils/iptables.go
+++ b/utils/iptables.go
@@ -569,11 +569,29 @@ func InitIptablesFlags() {
 	}
 }
 
+func ShouldConfigurePrivateNicSnat(ip string) bool {
+	return IsIpv4Address(ip) && !IsSLB()
+}
+
+func SyncSnatRuleForPrivateNic(nicName, ip, netmask string) error {
+	if ShouldConfigurePrivateNicSnat(ip) {
+		return AddSnatRuleForPrivateNic(nicName, ip, netmask)
+	}
+
+	return RemoveSnatRuleForPrivateNic(nicName, ip, netmask)
+}
+
+func RemoveAllPrivateNicSnatRules() error {
+	table := NewIpTables(NatTable)
+	table.RemoveIpTableRuleByComments(PrivateNicSNATComment)
+	return table.Apply()
+}
+
 func AddSnatRuleForPrivateNic(nicName, ip, netmask string) (err error) {
-	if ip == "" || strings.Contains(ip, ":") {
-		/* TODO: add ipv6 support */
+	if !ShouldConfigurePrivateNicSnat(ip) {
 		return nil
 	}
+
 	table := NewIpTables(NatTable)
 	address, err := GetNetworkNumber(ip, netmask)
 	PanicOnError(err)
@@ -587,8 +605,7 @@ func AddSnatRuleForPrivateNic(nicName, ip, netmask string) (err error) {
 }
 
 func RemoveSnatRuleForPrivateNic(nicName, ip, netmask string) error {
-	if ip == "" || strings.Contains(ip, ":") {
-		/* TODO: add ipv6 support */
+	if !IsIpv4Address(ip) {
 		return nil
 	}
 

--- a/utils/private_nic_snat_test.go
+++ b/utils/private_nic_snat_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import "testing"
+
+func TestShouldConfigurePrivateNicSnat(t *testing.T) {
+	originalBootstrapInfo := BootstrapInfo
+	defer func() {
+		BootstrapInfo = originalBootstrapInfo
+	}()
+
+	BootstrapInfo = map[string]interface{}{}
+	if !ShouldConfigurePrivateNicSnat("192.168.10.1") {
+		t.Fatal("IPv4 private SNAT should be configured for non-SLB appliance")
+	}
+
+	if ShouldConfigurePrivateNicSnat("2001:db8::1") {
+		t.Fatal("IPv6 private SNAT should not be configured")
+	}
+
+	BootstrapInfo = map[string]interface{}{
+		"applianceVmSubType": APPLIANCETYPE_SLB,
+	}
+	if ShouldConfigurePrivateNicSnat("192.168.10.1") {
+		t.Fatal("private SNAT should not be configured for SLB appliance")
+	}
+}
+
+func TestGetBootStrapPrivateNicInfo(t *testing.T) {
+	originalBootstrapInfo := BootstrapInfo
+	defer func() {
+		BootstrapInfo = originalBootstrapInfo
+	}()
+
+	BootstrapInfo = map[string]interface{}{
+		"additionalNics": []interface{}{
+			map[string]interface{}{
+				"category":   NIC_TYPE_PUBLIC,
+				"deviceName": "eth0",
+				"ip":         "10.0.0.2",
+				"netmask":    "255.255.255.0",
+			},
+			map[string]interface{}{
+				"category":   NIC_TYPE_PRIVATE,
+				"deviceName": "eth1",
+				"mac":        "52:54:00:12:34:56",
+				"ip":         "192.168.10.1",
+				"netmask":    "255.255.255.0",
+			},
+			map[string]interface{}{
+				"category":     NIC_TYPE_PRIVATE,
+				"deviceName":   "eth2",
+				"ip6":          "2001:db8::1",
+				"gateway6":     "2001:db8::ff",
+				"prefixLength": 64,
+			},
+		},
+	}
+
+	nics := GetBootStrapPrivateNicInfo()
+	if len(nics) != 2 {
+		t.Fatalf("expected two private nics, got %d", len(nics))
+	}
+	if nics[0].Name != "eth1" || nics[0].Ip != "192.168.10.1" || nics[0].Netmask != "255.255.255.0" {
+		t.Fatalf("unexpected private IPv4 nic info: %+v", nics[0])
+	}
+	if nics[1].Name != "eth2" || nics[1].Ip6 != "2001:db8::1" ||
+		nics[1].Gateway6 != "2001:db8::ff" || nics[1].PrefixLength != 64 {
+		t.Fatalf("unexpected private IPv6 nic info: %+v", nics[1])
+	}
+}

--- a/zvrboot/zvrboot.go
+++ b/zvrboot/zvrboot.go
@@ -493,13 +493,19 @@ func configureVyos() {
 			}
 			if nic.category == "Private" {
 				err = utils.InitNicFirewall(nic.name, nic.ip, false, utils.IPTABLES_ACTION_REJECT)
-				// add private SNAT rule in iptables
-				err = utils.AddSnatRuleForPrivateNic(nic.name, nic.ip, nic.netmask)
+				if err != nil {
+					log.Debugf("InitNicFirewall for nic %s failed: %s", nic.name, err.Error())
+				}
+
+				err = utils.SyncSnatRuleForPrivateNic(nic.name, nic.ip, nic.netmask)
+				if err != nil {
+					log.Debugf("sync private nic SNAT rule for nic %s failed: %s", nic.name, err.Error())
+				}
 			} else {
 				err = utils.InitNicFirewall(nic.name, nic.ip, true, utils.IPTABLES_ACTION_REJECT)
-			}
-			if err != nil {
-				log.Debugf("InitNicFirewall for nic: %s failed", err.Error())
+				if err != nil {
+					log.Debugf("InitNicFirewall for nic %s failed: %s", nic.name, err.Error())
+				}
 			}
 		}
 	} else {
@@ -558,16 +564,7 @@ func configureVyos() {
 			setNicTree.AttachFirewallToInterface(nic.name, "in")
 
 			if nic.category == "Private" {
-				// add private SNAT rule in VyOS config tree
-				nicNo, _ := utils.GetNicNumber(nic.name)
-				ruleNo := utils.GetPrivateNicSNATRuleNumber(nicNo)
-				address, _ := utils.GetNetworkNumber(nic.ip, nic.netmask)
-				setNicTree.SetSnatWithRuleNumber(ruleNo,
-					fmt.Sprintf("outbound-interface %s", nic.name),
-					fmt.Sprintf("source address %s", address),
-					"destination address !224.0.0.0/8",
-					fmt.Sprintf("translation address %s", nic.ip),
-				)
+				plugin.SyncPrivateNicSnatRuleByVyos(setNicTree, nic.name, nic.ip, nic.netmask)
 			}
 			setNicTree.Apply(true)
 		}

--- a/zvrboot/zvrboot_utils.go
+++ b/zvrboot/zvrboot_utils.go
@@ -359,7 +359,9 @@ func configureBondNic(nic *utils.NicInfo) {
 
 	// Add SNAT rule for private bond interface
 	if nic.Category == "Private" {
-		utils.AddSnatRuleForPrivateNic(bondName, nic.Ip, nic.Netmask)
+		if err := utils.SyncSnatRuleForPrivateNic(bondName, nic.Ip, nic.Netmask); err != nil {
+			log.Debugf("sync private nic SNAT rule for bond %s failed: %s", bondName, err.Error())
+		}
 	}
 
 	log.Debugf("[configure: bond %s configured successfully]", bondName)
@@ -474,7 +476,9 @@ func configureNicInfo(nic *utils.NicInfo) {
 	}
 
 	if nic.Category == "Private" {
-		utils.AddSnatRuleForPrivateNic(nic.Name, nic.Ip, nic.Netmask)
+		if err := utils.SyncSnatRuleForPrivateNic(nic.Name, nic.Ip, nic.Netmask); err != nil {
+			log.Debugf("sync private nic SNAT rule for nic %s failed: %s", nic.Name, err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Backport/cherry-pick of zstack-vyos !1136 for ZSTAC-86067 to 5.5.28.

Original MR: http://dev.zstack.io:9080/zstackio/zstack-vyos/-/merge_requests/1136

## Changes
- Skip private-local SNAT creation for SLB appliances.
- Clean stale SLB private-local SNAT during SNAT sync, including empty SyncSnat hot-upgrade paths.
- Keep VPC private SNAT behavior for non-SLB appliances.
- Match existing public SNAT by full rule fields before allocating a new rule number.
- Add focused tests for SLB cleanup and public SNAT rule number allocation.

## Cherry-picked Commits
- 64e58914 <fix>[snat]: skip slb private snat
- b8fc3d4a <fix>[snat]: fix zvrboot nic log
- e9a21d3b <fix>[snat]: fix slb callback route
- dd799dc0 <fix>[snat]: revert slb callback route
- c31e9168 <fix>[snat]: guard private snat add
- 10a20860 <fix>[snat]: separate private nic query
- 7cdff252 <refactor>[snat]: clarify slb snat cleanup

## Testing
- [x] cherry-pick onto zstack/5.5.28 completed without conflicts
- [ ] go test ./plugin ./utils ./zvrboot blocked by existing unrelated test compile errors:
  - utils/radvd_test.go:107:76 missing comma
  - zvrboot/zvrboot_test.go:50:36 undefined utils.CROND_JSON_FILE
  - plugin/vip_euler_test.go undefined ParseVipCounterFromIptables

Resolves: ZSTAC-86067

sync from gitlab !1139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 私有网卡 SNAT 由新增/删除改为同步管理，减少配置不一致
  * 支持在 VyOS/SLB 场景下清理默认私有网卡 SNAT 规则
  * 公共网卡 SNAT 规则号在冲突或不可用时自动寻找可用编号

* **重构**
  * 统一私有网卡 SNAT 的同步与删除流程，简化 VyOS 配置写入逻辑
  * 引入更精确的私有网卡启动信息解析（含 IPv4/IPv6 与别名处理）

* **测试**
  * 新增并扩展 SNAT 规则同步/清理、规则号选择与启动信息解析的单元测试
<!-- end of auto-generated comment: release notes by coderabbit.ai -->