### PR TITLE
<fix>[lb]: sync ipvs rules in zvr

### DIFF
--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -37,8 +37,70 @@ var gHealthCheckMap map[string]*IpvsHealthCheckBackendServer
 var gHealthCheckMapLock sync.Mutex
 var ipvsadmLock sync.Mutex
 
+const (
+	healthCheckProtocolNone = "none"
+	healthCheckProtocolTCP  = "tcp"
+	healthCheckProtocolUDP  = "udp"
+
+	defaultHealthCheckTimeoutSeconds = 2
+)
+
 func isHealthCheckDisabled(protocol string) bool {
-	return strings.EqualFold(protocol, "none")
+	return strings.EqualFold(protocol, healthCheckProtocolNone)
+}
+
+func healthCheckTimeoutDuration(timeout int) time.Duration {
+	if timeout <= 0 {
+		return time.Duration(defaultHealthCheckTimeoutSeconds) * time.Second
+	}
+
+	return time.Duration(timeout) * time.Second
+}
+
+func shellQuoteArg(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+}
+
+func formatIpvsHealthCheckAddress(address string) (string, error) {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return "", fmt.Errorf("invalid ipvs health check address %q", address)
+	}
+	if ip.To4() == nil {
+		return fmt.Sprintf("[%s]", address), nil
+	}
+
+	return address, nil
+}
+
+func validateIpvsHealthCheckPort(port string) error {
+	value, err := strconv.Atoi(port)
+	if err != nil || value <= 0 || value > 65535 {
+		return fmt.Errorf("invalid ipvs health check port %q", port)
+	}
+
+	return nil
+}
+
+func ipvsHealthCheckEndpoint(address, port string) (string, error) {
+	formattedAddress, err := formatIpvsHealthCheckAddress(address)
+	if err != nil {
+		return "", err
+	}
+	if err := validateIpvsHealthCheckPort(port); err != nil {
+		return "", err
+	}
+
+	return shellQuoteArg(fmt.Sprintf("%s:%s", formattedAddress, port)), nil
+}
+
+func ipvsHealthCheckWeight(weight string) (string, error) {
+	value, err := strconv.Atoi(weight)
+	if err != nil || value < 0 {
+		return "", fmt.Errorf("invalid ipvs health check weight %q", weight)
+	}
+
+	return shellQuoteArg(weight), nil
 }
 
 func parseCommandOptions() {
@@ -50,9 +112,9 @@ func parseCommandOptions() {
 }
 
 func (bs *IpvsHealthCheckBackendServer) getBackendKey() string {
-	proto := "udp"
-	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
-		proto = "tcp"
+	proto := healthCheckProtocolUDP
+	if strings.ToLower(bs.ProtocolType) == healthCheckProtocolTCP || strings.ToLower(bs.ProtocolType) == "-t" {
+		proto = healthCheckProtocolTCP
 	}
 
 	return proto + "-" + bs.FrontIp + "-" + bs.FrontPort + "-" + bs.BackendIp + "-" + bs.BackendPort
@@ -74,12 +136,16 @@ func (bs *IpvsHealthCheckBackendServer) equal(other *IpvsHealthCheckBackendServe
 }
 
 func (bs *IpvsHealthCheckBackendServer) doHealthCheck() {
-	if isHealthCheckDisabled(bs.HealthCheckProtocol) {
+	protocol := strings.TrimSpace(strings.ToLower(bs.HealthCheckProtocol))
+	switch protocol {
+	case healthCheckProtocolNone:
 		bs.result <- true
-	} else if bs.HealthCheckProtocol == "udp" {
+	case healthCheckProtocolTCP:
+		bs.doTcpCheck()
+	case healthCheckProtocolUDP:
 		bs.doUdpCheck()
-	} else {
-		log.Debugf("unknow health check protocol %s", bs.HealthCheckProtocol)
+	default:
+		log.Debugf("unknown health check protocol %q", bs.HealthCheckProtocol)
 		bs.result <- false
 	}
 }
@@ -93,22 +159,29 @@ func (bs *IpvsHealthCheckBackendServer) Install() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check backend: %v", err)
+		return
+	}
+	scheduler := shellQuoteArg(bs.Scheduler)
+	connectionType := shellQuoteArg(bs.ConnectionType)
+	weight, err := ipvsHealthCheckWeight(bs.Weight)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check weight: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("(ipvsadm -L %s %s:%s || ipvsadm -A %s %s:%s -s %s); "+
-		"ipvsadm -a %s %s:%s -r  %s:%s %s -w %s -x %d -y %d",
-		proto, frontIp, bs.FrontPort,
-		proto, frontIp, bs.FrontPort, bs.Scheduler,
-		proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort, bs.ConnectionType, bs.Weight, bs.MaxConnection, bs.MinConnection)
+	cmd := fmt.Sprintf("(ipvsadm -L %s %s || ipvsadm -A %s %s -s %s); "+
+		"ipvsadm -a %s %s -r  %s %s -w %s -x %d -y %d",
+		proto, frontService,
+		proto, frontService, scheduler,
+		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection)
 
 	b := utils.Bash{
 		Command: cmd,
@@ -127,51 +200,31 @@ func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip uninstalling invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip uninstalling invalid ipvs health check backend: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -d %s %s:%s -r %s:%s", proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort)
+	cmd := fmt.Sprintf("ipvsadm -d %s %s -r %s", proto, frontService, backendService)
 	b := utils.Bash{
 		Command: cmd,
 		Sudo:    true,
 	}
 	b.Run()
 
-	/* if there is no backend, remove the service */
-	conf, err := plugin.NewIpvsConfFromSave()
-	if err != nil {
-		log.Debugf("[ipvsHealthCheck] ipvsadm-save to config failed %+v", err)
+	cmd = fmt.Sprintf("ipvsadm -L %s %s 2>/dev/null | grep -q -- '->' || ipvsadm -D %s %s",
+		proto, frontService, proto, frontService)
+	b = utils.Bash{
+		Command: cmd,
+		Sudo:    true,
 	}
-
-	for _, fs := range conf.Services {
-		if len(fs.BackendServers) == 0 {
-			proto := "-u"
-			if strings.ToLower(fs.ProtocolType) == "tcp" || strings.ToLower(fs.ProtocolType) == "-t" {
-				proto = "-t"
-			}
-			frontIp := fs.FrontIp
-			ip := net.ParseIP(frontIp)
-			if ip != nil && ip.To4() == nil {
-				frontIp = fmt.Sprintf("[%s]", frontIp)
-			}
-
-			cmd := fmt.Sprintf("ipvsadm -D %s %s:%s", proto, frontIp, fs.FrontPort)
-			b := utils.Bash{
-				Command: cmd,
-				Sudo:    true,
-			}
-			b.Run()
-		}
-	}
-
+	b.Run()
 }
 
 func (bs *IpvsHealthCheckBackendServer) EditBackendServer() {
@@ -182,19 +235,25 @@ func (bs *IpvsHealthCheckBackendServer) EditBackendServer() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check backend: %v", err)
+		return
+	}
+	connectionType := shellQuoteArg(bs.ConnectionType)
+	weight, err := ipvsHealthCheckWeight(bs.Weight)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check weight: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -e %s %s:%s -r  %s:%s %s -w %s -x %d -y %d",
-		proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort, bs.ConnectionType, bs.Weight, bs.MaxConnection, bs.MinConnection)
+	cmd := fmt.Sprintf("ipvsadm -e %s %s -r  %s %s -w %s -x %d -y %d",
+		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection)
 
 	b := utils.Bash{
 		Command: cmd,
@@ -211,13 +270,13 @@ func (bs *IpvsHealthCheckBackendServer) EditFrontService() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check service: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -E %s %s:%s -s %s", proto, frontIp, bs.FrontPort, bs.Scheduler)
+	cmd := fmt.Sprintf("ipvsadm -E %s %s -s %s", proto, frontService, shellQuoteArg(bs.Scheduler))
 	b := utils.Bash{
 		Command: cmd,
 		Sudo:    true,

--- a/ipvs_health_check/ipvs_health_check_tcp.go
+++ b/ipvs_health_check/ipvs_health_check_tcp.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (bs *IpvsHealthCheckBackendServer) doTcpCheck() {
+	addr := bs.BackendIp
+	ip := net.ParseIP(addr)
+	if ip != nil && ip.To4() == nil {
+		addr = fmt.Sprintf("[%s]", addr)
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, bs.HealthCheckPort),
+		healthCheckTimeoutDuration(bs.HealthCheckTimeout))
+	if err != nil {
+		log.Debugf("[tcp checker]: dial tcp %s:%d failed: %v", addr, bs.HealthCheckPort, err)
+		bs.result <- false
+		return
+	}
+
+	_ = conn.Close()
+	bs.result <- true
+}

--- a/ipvs_health_check/ipvs_health_check_test.go
+++ b/ipvs_health_check/ipvs_health_check_test.go
@@ -486,6 +486,12 @@ var _ = Describe("ipvs health check test", func() {
 		Expect(<-bs.result).To(BeTrue(), "none health check should keep backend healthy without udp probing")
 	})
 
+	It("ipvs health check: default timeout", func() {
+		Expect(healthCheckTimeoutDuration(0)).To(Equal(2 * time.Second))
+		Expect(healthCheckTimeoutDuration(-1)).To(Equal(2 * time.Second))
+		Expect(healthCheckTimeoutDuration(3)).To(Equal(3 * time.Second))
+	})
+
 	It("ipvs health check: test syncIpvsadmWithHealthCheck", func() {
 
 		wait := uint(bs1.HealthCheckInterval) * (bs1.HealthyThreshold + 2)

--- a/ipvs_health_check/ipvs_health_check_udp.go
+++ b/ipvs_health_check/ipvs_health_check_udp.go
@@ -18,7 +18,7 @@ func (bs *IpvsHealthCheckBackendServer) doUdpCheck() {
 		addr = fmt.Sprintf("[%s]", addr)
 	}
 	conn, err := net.DialTimeout("udp", fmt.Sprintf("%s:%d", addr, bs.HealthCheckPort),
-		time.Duration(bs.HealthCheckTimeout)*time.Second)
+		healthCheckTimeoutDuration(bs.HealthCheckTimeout))
 	if err != nil {
 		log.Debugf("[udp checher]: dial udp  %s:%d failed: %v", addr, bs.HealthCheckPort, err)
 		bs.result <- false
@@ -36,7 +36,7 @@ func (bs *IpvsHealthCheckBackendServer) doUdpCheck() {
 	}
 
 	buffer := make([]byte, 4)
-	conn.SetReadDeadline(time.Now().Add(time.Duration(bs.HealthCheckTimeout) * time.Second))
+	conn.SetReadDeadline(time.Now().Add(healthCheckTimeoutDuration(bs.HealthCheckTimeout)))
 	_, err = conn.Read(buffer)
 	if err != nil {
 		log.Debugf("[udp checher]: recv udp message from %s:%d failed: %v", bs.BackendIp, bs.HealthCheckPort, err)

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -111,6 +111,18 @@ func GetIpvsSchedulerTypeFromString(sch string) IpvsSchedulerType {
 	}
 }
 
+func getIpvsConnectionTypeFromForwardMode(forwardMode string) IpvsConnectionType {
+	switch strings.ToLower(forwardMode) {
+	case LB_FORWARD_MODE_FULL_NAT:
+		return IpvsConnectionTypeNAT
+	default:
+		// TODO(SUG-2795): add explicit nat/dr mappings when those forward
+		// modes are supported. Keep NAT as the current fallback for existing
+		// UDP IPVS listeners, which do not carry forwardMode.
+		return IpvsConnectionTypeNAT
+	}
+}
+
 func makeIpvsFirewallRuleDescription(lb LbInfo) string {
 	return fmt.Sprintf("%s-%v-%v", utils.IpvsComment, lb.LbUuid, lb.ListenerUuid)
 }
@@ -141,6 +153,40 @@ type IpvsFrontendService struct {
 	BackendServers map[string]*IpvsBackendServer
 	LbInfo
 	LbParams
+}
+
+func parseIpvsAclConfig(params []string) (string, []string, bool) {
+	var aclType string
+	var aclEntries []string
+	enableAcl := false
+	for _, param := range params {
+		parts := strings.SplitN(param, "::", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "accessControlStatus":
+			enableAcl = value == "enable"
+		case "aclType":
+			aclType = value
+		case "aclEntry":
+			for _, entry := range strings.Split(value, ",") {
+				entry = strings.TrimSpace(entry)
+				if entry != "" {
+					aclEntries = append(aclEntries, entry)
+				}
+			}
+		}
+	}
+
+	if !enableAcl || aclType == "" || len(aclEntries) == 0 {
+		return "", nil, false
+	}
+
+	return aclType, aclEntries, true
 }
 
 type IpvsConf struct {
@@ -319,6 +365,8 @@ func (ipvs *IpvsConf) ParseIpvs(content string) error {
 			info.LoadBalancerPort, _ = strconv.Atoi(port)
 			if protocol == "-u" {
 				info.Mode = "udp"
+			} else if protocol == "-t" {
+				info.Mode = "tcp"
 			}
 
 			param := LbParams{}
@@ -342,6 +390,22 @@ func (ipvs *IpvsConf) ParseIpvs(content string) error {
 			service.ConnectionType = items[5]
 			weight := items[7]
 			backend := NewIpvsBackendServer(backendIp, backendPort, weight, service)
+			for i := 8; i+1 < len(items); i++ {
+				switch items[i] {
+				case "-x":
+					value, err := strconv.Atoi(items[i+1])
+					if err != nil {
+						return fmt.Errorf("invalid ipvs max connection %q", items[i+1])
+					}
+					backend.maxConnection = value
+				case "-y":
+					value, err := strconv.Atoi(items[i+1])
+					if err != nil {
+						return fmt.Errorf("invalid ipvs min connection %q", items[i+1])
+					}
+					backend.minConnection = value
+				}
+			}
 			service.BackendServers[backend.GetBackendKey()] = backend
 		}
 	}
@@ -380,7 +444,7 @@ func NewIpvsBackendServer(serverIp, serverPort, weight string, frontService *Ipv
 }
 
 func NewIpvsFrontService(info LbInfo, param LbParams, frontIp string, servers map[string]*IpvsBackendServer) *IpvsFrontendService {
-	connectionType := IpvsConnectionTypeNAT.String()
+	connectionType := getIpvsConnectionTypeFromForwardMode(info.ForwardMode).String()
 	protocolType := "-u"
 	if info.Mode == LB_MODE_HTTPS || info.Mode == LB_MODE_HTTP || info.Mode == LB_MODE_TCP {
 		protocolType = "-t"
@@ -409,6 +473,238 @@ func NewIpvsConfFromSave() (*IpvsConf, error) {
 
 func (fs *IpvsFrontendService) getFrontendServiceKey() string {
 	return fs.ProtocolType + "-" + fs.FrontIp + "-" + fs.FrontPort
+}
+
+func validateIpvsAddress(address string) error {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return fmt.Errorf("invalid ipvs address %q", address)
+	}
+
+	return nil
+}
+
+func formatIpvsAddress(address string) string {
+	ip := net.ParseIP(address)
+	if ip.To4() == nil {
+		return fmt.Sprintf("[%s]", address)
+	}
+
+	return address
+}
+
+func validateIpvsPort(port string) error {
+	value, err := strconv.Atoi(port)
+	if err != nil || value <= 0 || value > 65535 {
+		return fmt.Errorf("invalid ipvs port %q", port)
+	}
+
+	return nil
+}
+
+func validateIpvsScheduler(scheduler string) error {
+	switch scheduler {
+	case IpvsSchedulerRR.String(), IpvsSchedulerWRR.String(), IpvsSchedulerLC.String(), IpvsSchedulerSH.String():
+		return nil
+	default:
+		return fmt.Errorf("invalid ipvs scheduler %q", scheduler)
+	}
+}
+
+func validateIpvsConnectionType(connectionType string) error {
+	switch connectionType {
+	case IpvsConnectionTypeDR.String(), IpvsConnectionTypeNAT.String(), IpvsConnectionTypeTUNNEL.String():
+		return nil
+	default:
+		return fmt.Errorf("invalid ipvs connection type %q", connectionType)
+	}
+}
+
+func validateIpvsWeight(weight string) error {
+	value, err := strconv.Atoi(weight)
+	if err != nil || value < 0 {
+		return fmt.Errorf("invalid ipvs weight %q", weight)
+	}
+
+	return nil
+}
+
+func ipvsProtocolArg(protocol string) string {
+	if strings.EqualFold(protocol, "tcp") || strings.EqualFold(protocol, "-t") {
+		return "-t"
+	}
+
+	return "-u"
+}
+
+func validateIpvsFrontendService(fs *IpvsFrontendService) error {
+	if err := validateIpvsAddress(fs.FrontIp); err != nil {
+		return err
+	}
+	if err := validateIpvsPort(fs.FrontPort); err != nil {
+		return err
+	}
+	if err := validateIpvsScheduler(fs.Scheduler); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateIpvsBackendServer(bs *IpvsBackendServer) error {
+	if err := validateIpvsFrontendService(bs.IpvsFrontendService); err != nil {
+		return err
+	}
+	if err := validateIpvsAddress(bs.BackendIp); err != nil {
+		return err
+	}
+	if err := validateIpvsPort(bs.BackendPort); err != nil {
+		return err
+	}
+	if err := validateIpvsConnectionType(bs.ConnectionType); err != nil {
+		return err
+	}
+	if err := validateIpvsWeight(bs.Weight); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fs *IpvsFrontendService) frontServiceAddress() string {
+	return fmt.Sprintf("%s:%s", formatIpvsAddress(fs.FrontIp), fs.FrontPort)
+}
+
+func (bs *IpvsBackendServer) backendAddress() string {
+	return fmt.Sprintf("%s:%s", formatIpvsAddress(bs.BackendIp), bs.BackendPort)
+}
+
+func makeIpvsAddServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -A %s %s -s %s", proto, fs.frontServiceAddress(), fs.Scheduler)
+}
+
+func makeIpvsEditServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -E %s %s -s %s", proto, fs.frontServiceAddress(), fs.Scheduler)
+}
+
+func makeIpvsDeleteServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -D %s %s", proto, fs.frontServiceAddress())
+}
+
+func makeIpvsAddBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -a %s %s -r %s %s -w %s -x %d -y %d",
+		proto, bs.frontServiceAddress(), bs.backendAddress(), bs.ConnectionType, bs.Weight,
+		bs.maxConnection, bs.minConnection)
+}
+
+func makeIpvsEditBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -e %s %s -r %s %s -w %s -x %d -y %d",
+		proto, bs.frontServiceAddress(), bs.backendAddress(), bs.ConnectionType, bs.Weight,
+		bs.maxConnection, bs.minConnection)
+}
+
+func makeIpvsDeleteBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -d %s %s -r %s",
+		proto, bs.frontServiceAddress(), bs.backendAddress())
+}
+
+func sameIpvsBackend(current, desired *IpvsBackendServer) bool {
+	return current.ConnectionType == desired.ConnectionType &&
+		current.Weight == desired.Weight &&
+		current.maxConnection == desired.maxConnection &&
+		current.minConnection == desired.minConnection
+}
+
+func appendIpvsCommand(commands *[]string, cmd string) {
+	*commands = append(*commands, cmd)
+}
+
+func syncIpvsadm(oldConf, desiredConf *IpvsConf) error {
+	if desiredConf == nil {
+		desiredConf = &IpvsConf{Services: map[string]*IpvsFrontendService{}}
+	}
+	if oldConf == nil {
+		oldConf = &IpvsConf{Services: map[string]*IpvsFrontendService{}}
+	}
+
+	currentConf, err := NewIpvsConfFromSave()
+	if err != nil {
+		return err
+	}
+
+	var commands []string
+	for key, fs := range desiredConf.Services {
+		if err := validateIpvsFrontendService(fs); err != nil {
+			return err
+		}
+		current := currentConf.Services[key]
+		if current == nil {
+			appendIpvsCommand(&commands, makeIpvsAddServiceCommand(fs))
+		} else if current.Scheduler != fs.Scheduler {
+			appendIpvsCommand(&commands, makeIpvsEditServiceCommand(fs))
+		}
+
+		for backendKey, bs := range fs.BackendServers {
+			if err := validateIpvsBackendServer(bs); err != nil {
+				return err
+			}
+			currentBackend := (*IpvsBackendServer)(nil)
+			if current != nil {
+				currentBackend = current.BackendServers[backendKey]
+			}
+
+			if currentBackend == nil {
+				appendIpvsCommand(&commands, makeIpvsAddBackendCommand(bs))
+			} else if !sameIpvsBackend(currentBackend, bs) {
+				appendIpvsCommand(&commands, makeIpvsEditBackendCommand(bs))
+			}
+		}
+
+		if old := oldConf.Services[key]; old != nil && current != nil {
+			for backendKey, oldBackend := range old.BackendServers {
+				if _, ok := fs.BackendServers[backendKey]; !ok {
+					if current.BackendServers[backendKey] != nil {
+						if err := validateIpvsBackendServer(oldBackend); err != nil {
+							return err
+						}
+						appendIpvsCommand(&commands, makeIpvsDeleteBackendCommand(oldBackend))
+					}
+				}
+			}
+		}
+	}
+
+	for key, current := range currentConf.Services {
+		if _, ok := desiredConf.Services[key]; ok {
+			continue
+		}
+		if err := validateIpvsFrontendService(current); err != nil {
+			return err
+		}
+		appendIpvsCommand(&commands, makeIpvsDeleteServiceCommand(current))
+	}
+
+	if len(commands) == 0 {
+		return nil
+	}
+
+	b := utils.Bash{
+		Command: "set -e; " + strings.Join(commands, "; "),
+		Sudo:    true,
+	}
+	ret, stdout, stderr, err := b.RunWithReturn()
+	if ret != 0 || err != nil {
+		return fmt.Errorf("failed to sync ipvsadm, ret: %d, stdout: %s, stderr: %s, error: %v",
+			ret, stdout, stderr, err)
+	}
+
+	return nil
 }
 
 func (fs *IpvsFrontendService) EnableIpvsLog() (err error) {
@@ -692,36 +988,13 @@ func RefreshIpvsBackend() error {
 	services := map[string]*IpvsFrontendService{}
 	for _, lb := range gIpvsLbInfoMap {
 		for _, listener := range lb {
-			if strings.ToLower(listener.Mode) != "udp" {
-				/* current only udp lb use ipvs */
+			if !isIpvsDataPlane(listener) {
 				continue
 			}
 
 			lbParam := ParseLbParams(listener)
 
-			// parse ACL config
-			var aclType string
-			var aclEntries []string
-			enableAcl := false
-			for _, param := range listener.Parameters {
-				parts := strings.Split(param, "::")
-				if len(parts) != 2 {
-					continue
-				}
-
-				switch parts[0] {
-				case "accessControlStatus":
-					// Acl are processed only when accessControlStatus is enabled
-					if parts[1] == "enable" {
-						enableAcl = true
-					}
-				case "aclType":
-					aclType = parts[1]
-				case "aclEntry":
-					// If multiple IP addresses are separated by commas (,), split them
-					aclEntries = strings.Split(parts[1], ",")
-				}
-			}
+			aclType, aclEntries, enableAcl := parseIpvsAclConfig(listener.Parameters)
 
 			var fs4, fs6 *IpvsFrontendService
 			if listener.Vip != "" {
@@ -764,7 +1037,13 @@ func RefreshIpvsBackend() error {
 		}
 	}
 
-	gIpvsConf = &IpvsConf{Services: services}
+	desiredConf := &IpvsConf{Services: services}
+	err := syncIpvsadm(gIpvsConf, desiredConf)
+	if err != nil {
+		return err
+	}
+
+	gIpvsConf = desiredConf
 	gIpvsConf.ReloadIpvsHealthCheckConfig()
 
 	if utils.IsSkipVyosIptables() {

--- a/plugin/ipvs_sync_test.go
+++ b/plugin/ipvs_sync_test.go
@@ -1,0 +1,153 @@
+package plugin
+
+import "testing"
+
+func TestIpvsCommandBuildersUseTcpFullNatBackendPort(t *testing.T) {
+	lb := LbInfo{
+		LbUuid:           "lb",
+		ListenerUuid:     "listener",
+		Vip:              "172.24.7.153",
+		LoadBalancerPort: 19086,
+		InstancePort:     8080,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+		Parameters:       []string{"balancerAlgorithm::roundrobin"},
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip, map[string]*IpvsBackendServer{})
+	bs := NewIpvsBackendServer("192.168.10.20", "8080", "100", fs)
+
+	if got, want := makeIpvsAddServiceCommand(fs), "ipvsadm -A -t 172.24.7.153:19086 -s rr"; got != want {
+		t.Fatalf("unexpected add service command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsAddBackendCommand(bs), "ipvsadm -a -t 172.24.7.153:19086 -r 192.168.10.20:8080 -m -w 100 -x 0 -y 0"; got != want {
+		t.Fatalf("unexpected add backend command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsDeleteServiceCommand(fs), "ipvsadm -D -t 172.24.7.153:19086"; got != want {
+		t.Fatalf("unexpected delete service command:\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestTcpIpvsListenerIsRoutedToIpvsDataPlane(t *testing.T) {
+	lb := LbInfo{
+		Mode:        LB_MODE_TCP,
+		DataPlane:   LB_DATA_PLANE_IPVS,
+		ForwardMode: LB_FORWARD_MODE_FULL_NAT,
+	}
+
+	if !isIpvsListener(lb) {
+		t.Fatal("expected tcp ipvs full_nat listener to use ipvs path")
+	}
+
+	lb.DataPlane = ""
+	lb.ForwardMode = ""
+	if isIpvsListener(lb) {
+		t.Fatal("expected default tcp listener to stay on haproxy path")
+	}
+}
+
+func TestIpvsCommandBuildersQuoteIPv6Address(t *testing.T) {
+	lb := LbInfo{
+		LbUuid:           "lb",
+		ListenerUuid:     "listener",
+		Vip6:             "2001:db8::10",
+		LoadBalancerPort: 19086,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+		Parameters:       []string{"balancerAlgorithm::rr"},
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip6, map[string]*IpvsBackendServer{})
+	bs := NewIpvsBackendServer("2001:db8::20", "8080", "1", fs)
+
+	if got, want := makeIpvsAddServiceCommand(fs), "ipvsadm -A -t [2001:db8::10]:19086 -s rr"; got != want {
+		t.Fatalf("unexpected ipv6 add service command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsDeleteBackendCommand(bs), "ipvsadm -d -t [2001:db8::10]:19086 -r [2001:db8::20]:8080"; got != want {
+		t.Fatalf("unexpected ipv6 delete backend command:\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestIpvsCommandBuildersRejectInvalidAddress(t *testing.T) {
+	lb := LbInfo{
+		Vip:              "172.24.7.153;touch /tmp/pwned",
+		LoadBalancerPort: 19086,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip, map[string]*IpvsBackendServer{})
+
+	if err := validateIpvsFrontendService(fs); err == nil {
+		t.Fatal("expected invalid frontend address to be rejected")
+	}
+}
+
+func TestSameIpvsBackendComparesConnectionLimits(t *testing.T) {
+	current := &IpvsBackendServer{
+		ConnectionType: "-m",
+		Weight:         "100",
+		maxConnection:  10,
+		minConnection:  1,
+	}
+	desired := &IpvsBackendServer{
+		ConnectionType: "-m",
+		Weight:         "100",
+		maxConnection:  20,
+		minConnection:  1,
+	}
+
+	if sameIpvsBackend(current, desired) {
+		t.Fatal("expected maxConnection change to require backend edit")
+	}
+}
+
+func TestParseIpvsKeepsBackendConnectionLimits(t *testing.T) {
+	conf := &IpvsConf{}
+	err := conf.ParseIpvs(`
+-A -t 172.24.7.153:19086 -s rr
+-a -t 172.24.7.153:19086 -r 192.168.10.20:8080 -m -w 100 -x 20 -y 3
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service := conf.Services["-t-172.24.7.153-19086"]
+	if service == nil {
+		t.Fatal("expected parsed service")
+	}
+	backend := service.BackendServers["192.168.10.20-8080"]
+	if backend == nil {
+		t.Fatal("expected parsed backend")
+	}
+	if backend.maxConnection != 20 || backend.minConnection != 3 {
+		t.Fatalf("unexpected connection limits: max=%d min=%d", backend.maxConnection, backend.minConnection)
+	}
+}
+
+func TestIpvsConnectionTypeFollowsForwardMode(t *testing.T) {
+	if got := getIpvsConnectionTypeFromForwardMode(LB_FORWARD_MODE_FULL_NAT); got != IpvsConnectionTypeNAT {
+		t.Fatalf("unexpected full_nat connection type: %s", got.String())
+	}
+}
+
+func TestParseIpvsAclConfigKeepsIPv6Entries(t *testing.T) {
+	aclType, entries, enabled := parseIpvsAclConfig([]string{
+		"accessControlStatus::enable",
+		"aclType::white",
+		"aclEntry::2001:db8::1/128, 192.168.10.0/24",
+	})
+
+	if !enabled {
+		t.Fatal("expected acl to be enabled")
+	}
+	if aclType != "white" {
+		t.Fatalf("unexpected acl type: %s", aclType)
+	}
+	if len(entries) != 2 || entries[0] != "2001:db8::1/128" || entries[1] != "192.168.10.0/24" {
+		t.Fatalf("unexpected acl entries: %#v", entries)
+	}
+}

--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -42,6 +42,9 @@ const (
 	LB_MODE_TCP   = "tcp"
 	LB_MODE_UDP   = "udp"
 
+	LB_DATA_PLANE_IPVS       = "ipvs"
+	LB_FORWARD_MODE_FULL_NAT = "full_nat"
+
 	LB_BACKEND_PREFIX_REG = "^nic-"
 
 	LISTENER_MAP_SIZE = 128
@@ -142,6 +145,8 @@ type LbInfo struct {
 	InstancePort       int                `json:"instancePort"`
 	LoadBalancerPort   int                `json:"loadBalancerPort"`
 	Mode               string             `json:"mode"`
+	DataPlane          string             `json:"dataPlane"`
+	ForwardMode        string             `json:"forwardMode"`
 	Parameters         []string           `json:"parameters"`
 	CertificateUuid    string             `json:"certificateUuid"`
 	SecurityPolicyType string             `json:"securityPolicyType"`
@@ -250,6 +255,22 @@ func ParseLbParams(lb LbInfo) LbParams {
 	}
 
 	return param
+}
+
+func isIpvsDataPlane(info LbInfo) bool {
+	if info.Mode == LB_MODE_UDP {
+		return true
+	}
+
+	if info.Mode != LB_MODE_TCP {
+		return false
+	}
+
+	return strings.EqualFold(info.DataPlane, LB_DATA_PLANE_IPVS) && strings.EqualFold(info.ForwardMode, LB_FORWARD_MODE_FULL_NAT)
+}
+
+func isTcpIpvsDataPlane(info LbInfo) bool {
+	return info.Mode == LB_MODE_TCP && strings.EqualFold(info.DataPlane, LB_DATA_PLANE_IPVS) && strings.EqualFold(info.ForwardMode, LB_FORWARD_MODE_FULL_NAT)
 }
 
 type Listener interface {
@@ -2175,8 +2196,12 @@ func AddLbs(lbs []Listener) error {
 }
 
 func isIpvsListener(info LbInfo) bool {
-	if info.Mode != LB_MODE_UDP {
+	if !isIpvsDataPlane(info) {
 		return false
+	}
+
+	if isTcpIpvsDataPlane(info) {
+		return true
 	}
 
 	confPath := makeLbConfFilePath(info)
@@ -2265,6 +2290,14 @@ func DeleteLbInternal(cmd *deleteLbCmd) {
 	ipvs := map[string]LbInfo{}
 	if len(cmd.Lbs) > 0 {
 		for _, lb := range cmd.Lbs {
+			if isTcpIpvsDataPlane(lb) {
+				if listener := GetListener(lb); listener != nil {
+					toDeleted = append(toDeleted, listener)
+				}
+				ipvs[lb.ListenerUuid] = lb
+				continue
+			}
+
 			if isIpvsListener(lb) {
 				ipvs[lb.ListenerUuid] = lb
 				continue


### PR DESCRIPTION
JIRA: ZSTAC-86152. Route TCP dataPlane=ipvs listeners to IPVS sync, keep listener-scoped delete cleanup, generate full_nat/Masq rules, and cover zvr IPVS sync behavior for the T1 TCP IPVS happy path.

sync from gitlab !1142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持按 TCP/UDP/IPVS数据平面与转发模式识别并进行更精确的健康检查。
  * 强化 IPVS 同步：服务/后端新增、编辑、删除按差异执行；支持 IPv6 命令参数安全引用。
  * 扩展负载均衡配置的解析字段（含数据平面与转发模式）并增强 ACL 参数解析。
* **Bug Fixes**
  * 修复健康检查协议与默认/自定义超时换算不一致的问题；未知协议按失败处理。
  * 防止卸载误删：仅在确认无后端绑定时移除前端服务。
* **Tests**
  * 补充并扩展 IPVS 命令生成、IPv6 引号、超时与 ACL 解析等用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->