### PR TITLE
ZSTAC-81326 skip bond slaves in pimd

### DIFF
--- a/plugin/auxiliary.go
+++ b/plugin/auxiliary.go
@@ -890,6 +890,7 @@ func configurePimdByVtysh(cmd *enablePimdCmd) error {
 	if err != nil {
 		return err
 	}
+	nics = getPimdConfigurableNics(nics)
 	for _, nic := range nics {
 		newCmd.SetInterface(nic.Name)
 	}
@@ -1017,14 +1018,9 @@ func stopVtyshPimd() error {
 		deleteCmd.SetRp(rp.RpAddress, rp.GroupAddress)
 	}
 
-	// 2. get all nics and delete
-	nics, err := utils.GetAllNics()
-	if err != nil {
-		return fmt.Errorf("failed to get network interfaces: %v", err)
-	}
-
-	for _, nic := range nics {
-		deleteCmd.SetInterface(nic.Name)
+	// 2. remove currently configured PIMD interfaces, including legacy entries.
+	for _, iface := range currentCmd.InterfaceCmd {
+		deleteCmd.SetInterface(iface.Name)
 	}
 
 	// 3. no match return

--- a/plugin/pimd.go
+++ b/plugin/pimd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"zstack-vyos/server"
@@ -18,6 +19,9 @@ const (
 	ENABLE_PIMD_PATH  = "/pimd/enable"
 	DISABLE_PIMD_PATH = "/pimd/disable"
 	GET_MROUTE_PATH   = "/pimd/route"
+
+	bondSlaveNameMarker = "-phy"
+	sysClassNetPath     = "/sys/class/net"
 )
 
 func getPimdConfDir() string {
@@ -75,6 +79,29 @@ func makePimdFirewallRuleDescription(name, nicname string) string {
 	return fmt.Sprintf("%s-for-%s", name, nicname)
 }
 
+func isPimdConfigurableNic(nic string) bool {
+	if strings.Contains(nic, bondSlaveNameMarker) {
+		return false
+	}
+
+	if _, err := os.Stat(filepath.Join(sysClassNetPath, nic, "master")); err == nil {
+		return false
+	}
+
+	return true
+}
+
+func getPimdConfigurableNics(nics map[string]utils.Nic) map[string]utils.Nic {
+	filtered := make(map[string]utils.Nic)
+	for name, nic := range nics {
+		if !isPimdConfigurableNic(nic.Name) {
+			continue
+		}
+		filtered[name] = nic
+	}
+	return filtered
+}
+
 func stopPimd() {
 	pid, err := utils.FindFirstPIDByPSExtern(true, getPimdBinPath())
 	if err == nil && pid != 0 {
@@ -122,6 +149,10 @@ rp-address {{.RpAddress}} {{.GroupAddress}}
 
 func (pimd *pimdAddNic) AddNic(nic string) error {
 	if pimdEnable == false {
+		return nil
+	}
+
+	if !isPimdConfigurableNic(nic) {
 		return nil
 	}
 
@@ -188,6 +219,10 @@ func (pimd *pimdAddNic) AddNic(nic string) error {
 func getPimdFirewallByNic(nics map[string]utils.Nic) []*utils.IpTableRule {
 	var rules []*utils.IpTableRule
 	for _, nic := range nics {
+		if !isPimdConfigurableNic(nic.Name) {
+			continue
+		}
+
 		/* pimd rule */
 		rule := utils.NewIpTableRule(utils.GetRuleSetName(nic.Name, utils.RULESET_LOCAL))
 		rule.SetAction(utils.IPTABLES_ACTION_RETURN).SetComment(utils.SystemTopRule)
@@ -250,6 +285,7 @@ func enablePimdHandler(ctx *server.CommandContext) interface{} {
 
 	/* enable firewall */
 	nics, _ := utils.GetAllNics()
+	nics = getPimdConfigurableNics(nics)
 	if utils.IsSkipVyosIptables() {
 		err := addPimdFirewallByIptables(nics)
 		utils.PanicOnError(err)
@@ -291,7 +327,7 @@ func enablePimdHandler(ctx *server.CommandContext) interface{} {
 		}
 		tree.Apply(false)
 	}
-  if !utils.IsEnableVyosCmd() {
+	if !utils.IsEnableVyosCmd() {
 		err := configurePimdByVtysh(cmd)
 		if err != nil {
 			utils.PanicOnError(err)
@@ -323,6 +359,7 @@ func disablePimdHandler(ctx *server.CommandContext) interface{} {
 	ctx.GetCommand(cmd)
 
 	nics, _ := utils.GetAllNics()
+	nics = getPimdConfigurableNics(nics)
 	if utils.IsSkipVyosIptables() {
 		removePimdFirewallByIptables(nics)
 	} else {
@@ -345,7 +382,7 @@ func disablePimdHandler(ctx *server.CommandContext) interface{} {
 		}
 		tree.Apply(false)
 	}
-  if !utils.IsEnableVyosCmd() {
+	if !utils.IsEnableVyosCmd() {
 		err := stopVtyshPimd()
 		if err != nil {
 			utils.PanicOnError(err)

--- a/plugin/pimd_test.go
+++ b/plugin/pimd_test.go
@@ -1,0 +1,37 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+	"zstack-vyos/utils"
+)
+
+func TestZSTAC81326PimdSkipsBondSriovSlaves(t *testing.T) {
+	nics := map[string]utils.Nic{
+		"eth1": {
+			Name: "eth1",
+			Mac:  "fa:20:cb:25:5d:01",
+		},
+		"eth1-phy1": {
+			Name: "eth1-phy1",
+			Mac:  "fa:20:cb:25:5d:01",
+		},
+		"eth1-phy2": {
+			Name: "eth1-phy2",
+			Mac:  "fa:20:cb:25:5d:01",
+		},
+	}
+
+	var rendered strings.Builder
+	for _, rule := range getPimdFirewallByNic(nics) {
+		rendered.WriteString(rule.String())
+	}
+
+	rules := rendered.String()
+	if !strings.Contains(rules, "eth1.local") || !strings.Contains(rules, "eth1.in") {
+		t.Fatalf("expected pimd rules for bond master eth1, got:\n%s", rules)
+	}
+	if strings.Contains(rules, "eth1-phy1") || strings.Contains(rules, "eth1-phy2") {
+		t.Fatalf("pimd rules must not be generated for bond slaves, got:\n%s", rules)
+	}
+}


### PR DESCRIPTION
Root cause:

Bond SR-IOV vRouter exposes eth1/eth2 as logical bond master interfaces and eth*-phy* as VF slave interfaces. /pimd/enable used all NICs from GetAllNics(), so it generated PIMD firewall rules for eth*-phy* slave interfaces. The firewall table only has chains for logical interfaces such as eth1.in/local and eth2.in/local, so iptables-restore failed when it referenced eth*-phy* chains.

Fix:

- Filter PIMD configurable NICs and skip bond slave interfaces.
- Apply the same filtering for iptables and vtysh enable paths.
- Skip bond slave NICs in the AddNic callback.
- Remove currently configured PIMD interfaces on vtysh disable so legacy entries can be cleaned.
- Add a focused unit test for bond SR-IOV slave filtering.

Verification:

- /usr/local/go/bin/gofmt -w plugin/pimd.go plugin/auxiliary.go plugin/pimd_test.go
- git diff --check: PASS
- go test ./plugin -run TestZSTAC81326PimdSkipsBondSriovSlaves -count=1: blocked by existing incomplete vendor tree, missing github.com/cilium/ebpf
- go test -tags loong64 ./plugin -run TestZSTAC81326PimdSkipsBondSriovSlaves -count=1: blocked by existing incomplete vendor tree, missing github.com/stretchr/testify/suite

Jira: http://jira.zstack.io/browse/ZSTAC-81326

sync from gitlab !1148