### PR TITLE
<merge>[lb]: integrate SUG-2795 T2/T6 zvr

### DIFF
--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -37,8 +37,70 @@ var gHealthCheckMap map[string]*IpvsHealthCheckBackendServer
 var gHealthCheckMapLock sync.Mutex
 var ipvsadmLock sync.Mutex
 
+const (
+	healthCheckProtocolNone = "none"
+	healthCheckProtocolTCP  = "tcp"
+	healthCheckProtocolUDP  = "udp"
+
+	defaultHealthCheckTimeoutSeconds = 2
+)
+
 func isHealthCheckDisabled(protocol string) bool {
-	return strings.EqualFold(protocol, "none")
+	return strings.EqualFold(protocol, healthCheckProtocolNone)
+}
+
+func healthCheckTimeoutDuration(timeout int) time.Duration {
+	if timeout <= 0 {
+		return time.Duration(defaultHealthCheckTimeoutSeconds) * time.Second
+	}
+
+	return time.Duration(timeout) * time.Second
+}
+
+func shellQuoteArg(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+}
+
+func formatIpvsHealthCheckAddress(address string) (string, error) {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return "", fmt.Errorf("invalid ipvs health check address %q", address)
+	}
+	if ip.To4() == nil {
+		return fmt.Sprintf("[%s]", address), nil
+	}
+
+	return address, nil
+}
+
+func validateIpvsHealthCheckPort(port string) error {
+	value, err := strconv.Atoi(port)
+	if err != nil || value <= 0 || value > 65535 {
+		return fmt.Errorf("invalid ipvs health check port %q", port)
+	}
+
+	return nil
+}
+
+func ipvsHealthCheckEndpoint(address, port string) (string, error) {
+	formattedAddress, err := formatIpvsHealthCheckAddress(address)
+	if err != nil {
+		return "", err
+	}
+	if err := validateIpvsHealthCheckPort(port); err != nil {
+		return "", err
+	}
+
+	return shellQuoteArg(fmt.Sprintf("%s:%s", formattedAddress, port)), nil
+}
+
+func ipvsHealthCheckWeight(weight string) (string, error) {
+	value, err := strconv.Atoi(weight)
+	if err != nil || value < 0 {
+		return "", fmt.Errorf("invalid ipvs health check weight %q", weight)
+	}
+
+	return shellQuoteArg(weight), nil
 }
 
 func parseCommandOptions() {
@@ -50,9 +112,9 @@ func parseCommandOptions() {
 }
 
 func (bs *IpvsHealthCheckBackendServer) getBackendKey() string {
-	proto := "udp"
-	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
-		proto = "tcp"
+	proto := healthCheckProtocolUDP
+	if strings.ToLower(bs.ProtocolType) == healthCheckProtocolTCP || strings.ToLower(bs.ProtocolType) == "-t" {
+		proto = healthCheckProtocolTCP
 	}
 
 	return proto + "-" + bs.FrontIp + "-" + bs.FrontPort + "-" + bs.BackendIp + "-" + bs.BackendPort
@@ -74,12 +136,16 @@ func (bs *IpvsHealthCheckBackendServer) equal(other *IpvsHealthCheckBackendServe
 }
 
 func (bs *IpvsHealthCheckBackendServer) doHealthCheck() {
-	if isHealthCheckDisabled(bs.HealthCheckProtocol) {
+	protocol := strings.TrimSpace(strings.ToLower(bs.HealthCheckProtocol))
+	switch protocol {
+	case healthCheckProtocolNone:
 		bs.result <- true
-	} else if bs.HealthCheckProtocol == "udp" {
+	case healthCheckProtocolTCP:
+		bs.doTcpCheck()
+	case healthCheckProtocolUDP:
 		bs.doUdpCheck()
-	} else {
-		log.Debugf("unknow health check protocol %s", bs.HealthCheckProtocol)
+	default:
+		log.Debugf("unknown health check protocol %q", bs.HealthCheckProtocol)
 		bs.result <- false
 	}
 }
@@ -93,22 +159,29 @@ func (bs *IpvsHealthCheckBackendServer) Install() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check backend: %v", err)
+		return
+	}
+	scheduler := shellQuoteArg(bs.Scheduler)
+	connectionType := shellQuoteArg(bs.ConnectionType)
+	weight, err := ipvsHealthCheckWeight(bs.Weight)
+	if err != nil {
+		log.Errorf("skip installing invalid ipvs health check weight: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("(ipvsadm -L %s %s:%s || ipvsadm -A %s %s:%s -s %s); "+
-		"ipvsadm -a %s %s:%s -r  %s:%s %s -w %s -x %d -y %d",
-		proto, frontIp, bs.FrontPort,
-		proto, frontIp, bs.FrontPort, bs.Scheduler,
-		proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort, bs.ConnectionType, bs.Weight, bs.MaxConnection, bs.MinConnection)
+	cmd := fmt.Sprintf("(ipvsadm -L %s %s || ipvsadm -A %s %s -s %s); "+
+		"ipvsadm -a %s %s -r  %s %s -w %s -x %d -y %d",
+		proto, frontService,
+		proto, frontService, scheduler,
+		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection)
 
 	b := utils.Bash{
 		Command: cmd,
@@ -127,51 +200,31 @@ func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip uninstalling invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip uninstalling invalid ipvs health check backend: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -d %s %s:%s -r %s:%s", proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort)
+	cmd := fmt.Sprintf("ipvsadm -d %s %s -r %s", proto, frontService, backendService)
 	b := utils.Bash{
 		Command: cmd,
 		Sudo:    true,
 	}
 	b.Run()
 
-	/* if there is no backend, remove the service */
-	conf, err := plugin.NewIpvsConfFromSave()
-	if err != nil {
-		log.Debugf("[ipvsHealthCheck] ipvsadm-save to config failed %+v", err)
+	cmd = fmt.Sprintf("ipvsadm -L %s %s 2>/dev/null | grep -q -- '->' || ipvsadm -D %s %s",
+		proto, frontService, proto, frontService)
+	b = utils.Bash{
+		Command: cmd,
+		Sudo:    true,
 	}
-
-	for _, fs := range conf.Services {
-		if len(fs.BackendServers) == 0 {
-			proto := "-u"
-			if strings.ToLower(fs.ProtocolType) == "tcp" || strings.ToLower(fs.ProtocolType) == "-t" {
-				proto = "-t"
-			}
-			frontIp := fs.FrontIp
-			ip := net.ParseIP(frontIp)
-			if ip != nil && ip.To4() == nil {
-				frontIp = fmt.Sprintf("[%s]", frontIp)
-			}
-
-			cmd := fmt.Sprintf("ipvsadm -D %s %s:%s", proto, frontIp, fs.FrontPort)
-			b := utils.Bash{
-				Command: cmd,
-				Sudo:    true,
-			}
-			b.Run()
-		}
-	}
-
+	b.Run()
 }
 
 func (bs *IpvsHealthCheckBackendServer) EditBackendServer() {
@@ -182,19 +235,25 @@ func (bs *IpvsHealthCheckBackendServer) EditBackendServer() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check service: %v", err)
+		return
 	}
-	backedIp := bs.BackendIp
-	ip = net.ParseIP(backedIp)
-	if ip != nil && ip.To4() == nil {
-		backedIp = fmt.Sprintf("[%s]", backedIp)
+	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check backend: %v", err)
+		return
+	}
+	connectionType := shellQuoteArg(bs.ConnectionType)
+	weight, err := ipvsHealthCheckWeight(bs.Weight)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check weight: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -e %s %s:%s -r  %s:%s %s -w %s -x %d -y %d",
-		proto, frontIp, bs.FrontPort, backedIp, bs.BackendPort, bs.ConnectionType, bs.Weight, bs.MaxConnection, bs.MinConnection)
+	cmd := fmt.Sprintf("ipvsadm -e %s %s -r  %s %s -w %s -x %d -y %d",
+		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection)
 
 	b := utils.Bash{
 		Command: cmd,
@@ -211,13 +270,13 @@ func (bs *IpvsHealthCheckBackendServer) EditFrontService() {
 	if strings.ToLower(bs.ProtocolType) == "tcp" || strings.ToLower(bs.ProtocolType) == "-t" {
 		proto = "-t"
 	}
-	frontIp := bs.FrontIp
-	ip := net.ParseIP(frontIp)
-	if ip != nil && ip.To4() == nil {
-		frontIp = fmt.Sprintf("[%s]", frontIp)
+	frontService, err := ipvsHealthCheckEndpoint(bs.FrontIp, bs.FrontPort)
+	if err != nil {
+		log.Errorf("skip editing invalid ipvs health check service: %v", err)
+		return
 	}
 
-	cmd := fmt.Sprintf("ipvsadm -E %s %s:%s -s %s", proto, frontIp, bs.FrontPort, bs.Scheduler)
+	cmd := fmt.Sprintf("ipvsadm -E %s %s -s %s", proto, frontService, shellQuoteArg(bs.Scheduler))
 	b := utils.Bash{
 		Command: cmd,
 		Sudo:    true,

--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -74,7 +74,8 @@ func (bs *IpvsHealthCheckBackendServer) equal(other *IpvsHealthCheckBackendServe
 }
 
 func (bs *IpvsHealthCheckBackendServer) doHealthCheck() {
-	switch strings.ToLower(bs.HealthCheckProtocol) {
+	protocol := strings.TrimSpace(strings.ToLower(bs.HealthCheckProtocol))
+	switch protocol {
 	case "none":
 		bs.result <- true
 	case "tcp":
@@ -82,7 +83,7 @@ func (bs *IpvsHealthCheckBackendServer) doHealthCheck() {
 	case "udp":
 		bs.doUdpCheck()
 	default:
-		log.Debugf("unknow health check protocol %s", bs.HealthCheckProtocol)
+		log.Debugf("unknow health check protocol %q", bs.HealthCheckProtocol)
 		bs.result <- false
 	}
 }

--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -74,11 +74,14 @@ func (bs *IpvsHealthCheckBackendServer) equal(other *IpvsHealthCheckBackendServe
 }
 
 func (bs *IpvsHealthCheckBackendServer) doHealthCheck() {
-	if isHealthCheckDisabled(bs.HealthCheckProtocol) {
+	switch strings.ToLower(bs.HealthCheckProtocol) {
+	case "none":
 		bs.result <- true
-	} else if bs.HealthCheckProtocol == "udp" {
+	case "tcp":
+		bs.doTcpCheck()
+	case "udp":
 		bs.doUdpCheck()
-	} else {
+	default:
 		log.Debugf("unknow health check protocol %s", bs.HealthCheckProtocol)
 		bs.result <- false
 	}

--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -8,9 +8,11 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -25,6 +27,7 @@ type IpvsHealthCheckBackendServer struct {
 	successCnt uint
 	failedCnt  uint
 	cancel     context.CancelFunc
+	cancelled  uint32
 	result     chan bool
 	plugin.IpvsHealthCheckBackendServer
 }
@@ -34,6 +37,7 @@ var confFile string
 var pidFile string
 
 var gHealthCheckMap map[string]*IpvsHealthCheckBackendServer
+var gDisabledHealthCheckMap map[string]*IpvsHealthCheckBackendServer
 var gHealthCheckMapLock sync.Mutex
 var ipvsadmLock sync.Mutex
 
@@ -131,6 +135,10 @@ func (bs *IpvsHealthCheckBackendServer) equal(other *IpvsHealthCheckBackendServe
 		bs.BackendPort == other.BackendPort &&
 		bs.HealthCheckProtocol == other.HealthCheckProtocol &&
 		bs.HealthCheckPort == other.HealthCheckPort &&
+		bs.HealthCheckInterval == other.HealthCheckInterval &&
+		bs.HealthCheckTimeout == other.HealthCheckTimeout &&
+		bs.HealthyThreshold == other.HealthyThreshold &&
+		bs.UnhealthyThreshold == other.UnhealthyThreshold &&
 		bs.MaxConnection == other.MaxConnection &&
 		bs.MinConnection == other.MinConnection
 }
@@ -178,9 +186,11 @@ func (bs *IpvsHealthCheckBackendServer) Install() {
 	}
 
 	cmd := fmt.Sprintf("(ipvsadm -L %s %s || ipvsadm -A %s %s -s %s); "+
-		"ipvsadm -a %s %s -r  %s %s -w %s -x %d -y %d",
+		"(ipvsadm -e %s %s -r %s %s -w %s -x %d -y %d || "+
+		"ipvsadm -a %s %s -r %s %s -w %s -x %d -y %d)",
 		proto, frontService,
 		proto, frontService, scheduler,
+		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection,
 		proto, frontService, backendService, connectionType, weight, bs.MaxConnection, bs.MinConnection)
 
 	b := utils.Bash{
@@ -205,6 +215,13 @@ func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 		log.Errorf("skip uninstalling invalid ipvs health check service: %v", err)
 		return
 	}
+	formattedFrontIp, err := formatIpvsHealthCheckAddress(bs.FrontIp)
+	if err != nil {
+		log.Errorf("skip uninstalling invalid ipvs health check service: %v", err)
+		return
+	}
+	frontServicePattern := shellQuoteArg(fmt.Sprintf("^-a[[:space:]]+%s[[:space:]]+%s:[[:space:]]*%s[[:space:]]",
+		proto, regexp.QuoteMeta(formattedFrontIp), regexp.QuoteMeta(bs.FrontPort)))
 	backendService, err := ipvsHealthCheckEndpoint(bs.BackendIp, bs.BackendPort)
 	if err != nil {
 		log.Errorf("skip uninstalling invalid ipvs health check backend: %v", err)
@@ -218,8 +235,8 @@ func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 	}
 	b.Run()
 
-	cmd = fmt.Sprintf("ipvsadm -L %s %s 2>/dev/null | grep -q -- '->' || ipvsadm -D %s %s",
-		proto, frontService, proto, frontService)
+	cmd = fmt.Sprintf("ipvsadm-save -n | grep -Eq %s || ipvsadm -D %s %s",
+		frontServicePattern, proto, frontService)
 	b = utils.Bash{
 		Command: cmd,
 		Sudo:    true,
@@ -290,6 +307,46 @@ func (bs *IpvsHealthCheckBackendServer) setStatus(status bool) {
 	bs.successCnt = 0
 }
 
+func (bs *IpvsHealthCheckBackendServer) isCancelled() bool {
+	return atomic.LoadUint32(&bs.cancelled) != 0
+}
+
+func (bs *IpvsHealthCheckBackendServer) applyHealthCheckResult(result bool) bool {
+	if bs.isCancelled() {
+		log.Debugf("[ipvsHealthCheck task] ignore health check result after cancellation for %s", bs.getBackendKey())
+		return false
+	}
+
+	if result {
+		if bs.successCnt == math.MaxUint-1 {
+			bs.successCnt = bs.HealthyThreshold
+		} else {
+			bs.successCnt++
+		}
+
+		bs.failedCnt = 0
+	} else {
+		if bs.failedCnt == math.MaxUint-1 {
+			bs.failedCnt = bs.UnhealthyThreshold
+		} else {
+			bs.failedCnt++
+		}
+		bs.successCnt = 0
+	}
+
+	log.Debugf("[ipvsHealthCheck task] %s: healthcheck resut:%v, current status %v:  successCnt: %d,%d failedCnt: %d:%d",
+		bs.getBackendKey(), result, bs.status,
+		bs.successCnt, bs.HealthyThreshold,
+		bs.failedCnt, bs.UnhealthyThreshold)
+	if bs.failedCnt >= bs.UnhealthyThreshold && bs.status {
+		bs.UnInstall()
+	} else if bs.successCnt >= bs.HealthyThreshold && !bs.status {
+		bs.Install()
+	}
+
+	return true
+}
+
 func (bs *IpvsHealthCheckBackendServer) Start() {
 	defer func() {
 		if err := recover(); err != nil {
@@ -308,8 +365,11 @@ func (bs *IpvsHealthCheckBackendServer) Start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	bs.cancel = cancel
+	if bs.isCancelled() {
+		cancel()
+		return
+	}
 	bs.result = make(chan bool, 1)
-	bs.status = false
 	bs.successCnt = 0
 	bs.failedCnt = 0
 
@@ -326,31 +386,9 @@ func (bs *IpvsHealthCheckBackendServer) Start() {
 	for {
 		select {
 		case result := <-bs.result:
-			if result {
-				if bs.successCnt == math.MaxUint-1 {
-					bs.successCnt = bs.HealthyThreshold
-				} else {
-					bs.successCnt++
-				}
-
-				bs.failedCnt = 0
-			} else {
-				if bs.failedCnt == math.MaxUint-1 {
-					bs.failedCnt = bs.UnhealthyThreshold
-				} else {
-					bs.failedCnt++
-				}
-				bs.successCnt = 0
-			}
-
-			log.Debugf("[ipvsHealthCheck task] %s: healthcheck resut:%v, current status %v:  successCnt: %d,%d failedCnt: %d:%d",
-				bs.getBackendKey(), result, bs.status,
-				bs.successCnt, bs.HealthyThreshold,
-				bs.failedCnt, bs.UnhealthyThreshold)
-			if bs.failedCnt >= bs.UnhealthyThreshold && bs.status {
-				bs.UnInstall()
-			} else if bs.successCnt >= bs.HealthyThreshold && !bs.status {
-				bs.Install()
+			if !bs.applyHealthCheckResult(result) {
+				taskTimer.Stop()
+				return
 			}
 			taskTimer.Reset(time.Duration(bs.HealthCheckInterval) * time.Second)
 
@@ -369,10 +407,15 @@ func (bs *IpvsHealthCheckBackendServer) Start() {
 
 func (bs *IpvsHealthCheckBackendServer) Stop() {
 	log.Debugf("[ipvsHealthCheck task] stop health check task for %s", bs.getBackendKey())
+	bs.Cancel()
+	bs.UnInstall()
+}
+
+func (bs *IpvsHealthCheckBackendServer) Cancel() {
+	atomic.StoreUint32(&bs.cancelled, 1)
 	if bs.cancel != nil {
 		bs.cancel()
 	}
-	bs.UnInstall()
 }
 
 func reloadIpvsHealthCheckConfig() {
@@ -391,6 +434,7 @@ func reloadIpvsHealthCheckConfig() {
 
 	log.Debugf("[ipvsHealthCheck reload] load config file success, %++v", conf)
 	checkers := map[string]*IpvsHealthCheckBackendServer{}
+	disabledBackends := map[string]*IpvsHealthCheckBackendServer{}
 	if conf.Services != nil {
 		for _, fs := range conf.Services {
 			log.Debugf("[ipvsHealthCheck reload] new Services: %+v", fs)
@@ -402,6 +446,10 @@ func reloadIpvsHealthCheckConfig() {
 				}
 
 				log.Debugf("[ipvsHealthCheck reload] new checker: %+v", nc)
+				if isHealthCheckDisabled(nc.HealthCheckProtocol) {
+					disabledBackends[nc.getBackendKey()] = &nc
+					continue
+				}
 				checkers[nc.getBackendKey()] = &nc
 			}
 		}
@@ -409,7 +457,9 @@ func reloadIpvsHealthCheckConfig() {
 
 	var toDeleted []string
 	var toStopped []*IpvsHealthCheckBackendServer
+	var toCancelled []*IpvsHealthCheckBackendServer
 	var toStarted []*IpvsHealthCheckBackendServer
+	var toInstalled []*IpvsHealthCheckBackendServer
 
 	func() {
 		gHealthCheckMapLock.Lock()
@@ -421,6 +471,11 @@ func reloadIpvsHealthCheckConfig() {
 			if !found {
 				log.Debugf("[ipvsHealthCheck reload] delete health check task for %s", old.getBackendKey())
 				toDeleted = append(toDeleted, old.getBackendKey())
+				if disabledBackends[old.getBackendKey()] != nil {
+					toCancelled = append(toCancelled, old)
+					continue
+				}
+				toStopped = append(toStopped, old)
 			} else {
 				/* 后端服务器的health check task 参数可能变化, 有两种处理方式:
 				1. copy health check配置参数给old
@@ -455,9 +510,6 @@ func reloadIpvsHealthCheckConfig() {
 
 		for _, key := range toDeleted {
 			log.Debugf("[ipvsHealthCheck reload] delete health check task for %s", key)
-			if gHealthCheckMap[key] != nil {
-				toStopped = append(toStopped, gHealthCheckMap[key])
-			}
 			delete(gHealthCheckMap, key)
 		}
 
@@ -466,14 +518,30 @@ func reloadIpvsHealthCheckConfig() {
 			_, found := gHealthCheckMap[check.getBackendKey()]
 			if !found {
 				log.Debugf("[ipvsHealthCheck reload] add new health check task %+v", check.getBackendKey())
+				if disabledBackend := gDisabledHealthCheckMap[check.getBackendKey()]; disabledBackend != nil && disabledBackend.status {
+					check.setStatus(true)
+				}
 				gHealthCheckMap[check.getBackendKey()] = check
 				toStarted = append(toStarted, check)
 			}
 		}
+
+		gDisabledHealthCheckMap = disabledBackends
+		for _, bs := range disabledBackends {
+			toInstalled = append(toInstalled, bs)
+		}
 	}()
+
+	for _, check := range toCancelled {
+		check.Cancel()
+	}
 
 	for _, check := range toStopped {
 		check.Stop()
+	}
+
+	for _, check := range toInstalled {
+		check.Install()
 	}
 
 	for _, check := range toStarted {
@@ -535,10 +603,10 @@ func syncIpvsadmWithHealthCheck() {
 
 				tempBsMap[temp.getBackendKey()] = &temp
 
-				if gHealthCheckMap[temp.getBackendKey()] == nil {
+				if gHealthCheckMap[temp.getBackendKey()] == nil && gDisabledHealthCheckMap[temp.getBackendKey()] == nil {
 					log.Debugf("[ipvsHealthCheck sync] delete backend server %+v", temp.getBackendKey())
 					go temp.UnInstall()
-				} else if !gHealthCheckMap[temp.getBackendKey()].status {
+				} else if gHealthCheckMap[temp.getBackendKey()] != nil && !gHealthCheckMap[temp.getBackendKey()].status {
 					log.Debugf("[ipvsHealthCheck sync] change backend server %+v status up", temp.getBackendKey())
 					gHealthCheckMap[temp.getBackendKey()].setStatus(true)
 				}
@@ -547,14 +615,15 @@ func syncIpvsadmWithHealthCheck() {
 
 		for _, gbs := range gHealthCheckMap {
 			if tempBsMap[gbs.getBackendKey()] == nil {
-				if isHealthCheckDisabled(gbs.HealthCheckProtocol) {
-					log.Debugf("[ipvsHealthCheck sync] reinstall disabled health check backend server %+v", gbs.getBackendKey())
-					toInstalled = append(toInstalled, gbs)
-					continue
-				}
-
 				log.Debugf("[ipvsHealthCheck sync] change backend server %+v status down", gbs.getBackendKey())
 				gbs.setStatus(false)
+			}
+		}
+
+		for _, gbs := range gDisabledHealthCheckMap {
+			if tempBsMap[gbs.getBackendKey()] == nil {
+				log.Debugf("[ipvsHealthCheck sync] reinstall disabled health check backend server %+v", gbs.getBackendKey())
+				toInstalled = append(toInstalled, gbs)
 			}
 		}
 	}()
@@ -579,6 +648,10 @@ func fastUpBackendServers() {
 		gbs.setStatus(false)
 		go gbs.doHealthCheck()
 	}
+
+	for _, gbs := range gDisabledHealthCheckMap {
+		go gbs.Install()
+	}
 }
 
 func main() {
@@ -599,6 +672,7 @@ func main() {
 	}
 
 	gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+	gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
 
 	interruptChan := make(chan os.Signal, 1)
 	signal.Notify(interruptChan, syscall.SIGHUP, syscall.SIGUSR1)

--- a/ipvs_health_check/ipvs_health_check_tcp.go
+++ b/ipvs_health_check/ipvs_health_check_tcp.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (bs *IpvsHealthCheckBackendServer) doTcpCheck() {
+	addr := bs.BackendIp
+	ip := net.ParseIP(addr)
+	if ip != nil && ip.To4() == nil {
+		addr = fmt.Sprintf("[%s]", addr)
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, bs.HealthCheckPort),
+		healthCheckTimeoutDuration(bs.HealthCheckTimeout))
+	if err != nil {
+		log.Debugf("[tcp checker]: dial tcp %s:%d failed: %v", addr, bs.HealthCheckPort, err)
+		bs.result <- false
+		return
+	}
+
+	_ = conn.Close()
+	bs.result <- true
+}

--- a/ipvs_health_check/ipvs_health_check_tcp.go
+++ b/ipvs_health_check/ipvs_health_check_tcp.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (bs *IpvsHealthCheckBackendServer) doTcpCheck() {
+	addr := bs.BackendIp
+	ip := net.ParseIP(addr)
+	if ip != nil && ip.To4() == nil {
+		addr = fmt.Sprintf("[%s]", addr)
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, bs.HealthCheckPort),
+		time.Duration(bs.HealthCheckTimeout)*time.Second)
+	if err != nil {
+		log.Debugf("[tcp checker]: dial tcp %s:%d failed: %v", addr, bs.HealthCheckPort, err)
+		bs.result <- false
+		return
+	}
+
+	_ = conn.Close()
+	bs.result <- true
+}

--- a/ipvs_health_check/ipvs_health_check_test.go
+++ b/ipvs_health_check/ipvs_health_check_test.go
@@ -486,6 +486,12 @@ var _ = Describe("ipvs health check test", func() {
 		Expect(<-bs.result).To(BeTrue(), "none health check should keep backend healthy without udp probing")
 	})
 
+	It("ipvs health check: default timeout", func() {
+		Expect(healthCheckTimeoutDuration(0)).To(Equal(2 * time.Second))
+		Expect(healthCheckTimeoutDuration(-1)).To(Equal(2 * time.Second))
+		Expect(healthCheckTimeoutDuration(3)).To(Equal(3 * time.Second))
+	})
+
 	It("ipvs health check: test syncIpvsadmWithHealthCheck", func() {
 
 		wait := uint(bs1.HealthCheckInterval) * (bs1.HealthyThreshold + 2)

--- a/ipvs_health_check/ipvs_health_check_test.go
+++ b/ipvs_health_check/ipvs_health_check_test.go
@@ -97,6 +97,7 @@ var _ = Describe("ipvs health check test", func() {
 
 	confFile = plugin.IPVS_HEALTH_CHECK_CONFIG_FILE
 	gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+	gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
 
 	It("ipvs health check: prepare env", func() {
 		mgtNicForUT, pubNicForUT, priNicForUT = utils.SetupSlbHaBootStrap()
@@ -490,6 +491,123 @@ var _ = Describe("ipvs health check test", func() {
 		Expect(healthCheckTimeoutDuration(0)).To(Equal(2 * time.Second))
 		Expect(healthCheckTimeoutDuration(-1)).To(Equal(2 * time.Second))
 		Expect(healthCheckTimeoutDuration(3)).To(Equal(3 * time.Second))
+	})
+
+	It("ipvs health check: test tcp to none reload keeps desired backend", func() {
+		old := bs1
+		old.ProtocolType = "tcp"
+		old.HealthCheckProtocol = "tcp"
+		old.status = true
+		ctx, cancel := context.WithCancel(context.Background())
+		old.cancel = cancel
+		DeferCleanup(func() {
+			old.Cancel()
+			disabled := gDisabledHealthCheckMap[old.getBackendKey()]
+			if disabled != nil {
+				disabled.UnInstall()
+			}
+			gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+			gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		})
+
+		disabled := bs1.IpvsHealthCheckBackendServer
+		disabled.ProtocolType = "tcp"
+		disabled.HealthCheckProtocol = "none"
+		conf := plugin.IpvsHealthCheckConf{
+			Services: []*plugin.IpvsHealthCheckFrontService{{
+				LbUuid:         disabled.LbUuid,
+				ListenerUuid:   disabled.ListenerUuid,
+				ConnectionType: disabled.ConnectionType,
+				ProtocolType:   disabled.ProtocolType,
+				Scheduler:      disabled.Scheduler,
+				FrontIp:        disabled.FrontIp,
+				FrontPort:      disabled.FrontPort,
+				BackendServers: []*plugin.IpvsHealthCheckBackendServer{&disabled},
+			}},
+		}
+
+		gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{old.getBackendKey(): &old}
+		gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		utils.JsonStoreConfig(plugin.IPVS_HEALTH_CHECK_CONFIG_FILE, conf)
+		reloadIpvsHealthCheckConfig()
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+			Fail("old tcp checker should be cancelled")
+		}
+
+		if _, found := gHealthCheckMap[old.getBackendKey()]; found {
+			Fail("none backend must not remain in active health check tasks")
+		}
+		if _, found := gDisabledHealthCheckMap[old.getBackendKey()]; !found {
+			Fail("none backend should be tracked as desired disabled backend")
+		}
+		Expect(old.status).To(BeTrue(), "tcp to none reload must not uninstall the desired real server")
+	})
+
+	It("ipvs health check: test none to tcp reload inherits installed backend status", func() {
+		disabled := bs1
+		disabled.ProtocolType = "tcp"
+		disabled.HealthCheckProtocol = "none"
+		disabled.status = true
+		DeferCleanup(func() {
+			gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+			gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		})
+
+		active := bs1.IpvsHealthCheckBackendServer
+		active.ProtocolType = "tcp"
+		active.HealthCheckProtocol = "tcp"
+		conf := plugin.IpvsHealthCheckConf{
+			Services: []*plugin.IpvsHealthCheckFrontService{{
+				LbUuid:         active.LbUuid,
+				ListenerUuid:   active.ListenerUuid,
+				ConnectionType: active.ConnectionType,
+				ProtocolType:   active.ProtocolType,
+				Scheduler:      active.Scheduler,
+				FrontIp:        active.FrontIp,
+				FrontPort:      active.FrontPort,
+				BackendServers: []*plugin.IpvsHealthCheckBackendServer{&active},
+			}},
+		}
+
+		gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{disabled.getBackendKey(): &disabled}
+		utils.JsonStoreConfig(plugin.IPVS_HEALTH_CHECK_CONFIG_FILE, conf)
+		reloadIpvsHealthCheckConfig()
+
+		check := gHealthCheckMap[disabled.getBackendKey()]
+		Expect(check).NotTo(BeNil())
+		Expect(check.status).To(BeTrue(), "none to tcp reload should inherit installed backend status")
+		check.Cancel()
+	})
+
+	It("ipvs health check: test cancelled checker ignores in-flight result", func() {
+		old := bs1
+		old.ProtocolType = "tcp"
+		old.HealthCheckProtocol = "tcp"
+		old.status = true
+		old.failedCnt = old.UnhealthyThreshold - 1
+		old.Cancel()
+
+		Expect(old.applyHealthCheckResult(false)).To(BeFalse())
+		Expect(old.status).To(BeTrue(), "cancelled checker must not uninstall desired backend")
+		Expect(old.failedCnt).To(Equal(old.UnhealthyThreshold - 1))
+	})
+
+	It("ipvs health check: test active checker applies in-flight result", func() {
+		old := bs1
+		old.ProtocolType = "tcp"
+		old.HealthCheckProtocol = "tcp"
+		old.status = true
+		old.successCnt = 0
+		old.failedCnt = 1
+
+		Expect(old.applyHealthCheckResult(true)).To(BeTrue())
+		Expect(old.status).To(BeTrue())
+		Expect(old.successCnt).To(Equal(uint(1)))
+		Expect(old.failedCnt).To(Equal(uint(0)))
 	})
 
 	It("ipvs health check: test syncIpvsadmWithHealthCheck", func() {

--- a/ipvs_health_check/ipvs_health_check_udp.go
+++ b/ipvs_health_check/ipvs_health_check_udp.go
@@ -18,7 +18,7 @@ func (bs *IpvsHealthCheckBackendServer) doUdpCheck() {
 		addr = fmt.Sprintf("[%s]", addr)
 	}
 	conn, err := net.DialTimeout("udp", fmt.Sprintf("%s:%d", addr, bs.HealthCheckPort),
-		time.Duration(bs.HealthCheckTimeout)*time.Second)
+		healthCheckTimeoutDuration(bs.HealthCheckTimeout))
 	if err != nil {
 		log.Debugf("[udp checher]: dial udp  %s:%d failed: %v", addr, bs.HealthCheckPort, err)
 		bs.result <- false
@@ -36,7 +36,7 @@ func (bs *IpvsHealthCheckBackendServer) doUdpCheck() {
 	}
 
 	buffer := make([]byte, 4)
-	conn.SetReadDeadline(time.Now().Add(time.Duration(bs.HealthCheckTimeout) * time.Second))
+	conn.SetReadDeadline(time.Now().Add(healthCheckTimeoutDuration(bs.HealthCheckTimeout)))
 	_, err = conn.Read(buffer)
 	if err != nil {
 		log.Debugf("[udp checher]: recv udp message from %s:%d failed: %v", bs.BackendIp, bs.HealthCheckPort, err)

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -1242,6 +1242,10 @@ func UpdateIpvsCounters() {
 		}
 		items := strings.Fields(line)
 		if items[0] == "TCP" || items[0] == "UDP" {
+			proto = "-u"
+			if items[0] == "TCP" {
+				proto = "-t"
+			}
 			ipports := strings.Split(items[1], ":")
 			frontIp = strings.Join(ipports[0:len(ipports)-1], ":")
 			frontIp = strings.Trim(frontIp, "[")
@@ -1300,6 +1304,10 @@ func UpdateIpvsCounters() {
 		}
 		items := strings.Fields(line)
 		if items[0] == "TCP" || items[0] == "UDP" {
+			proto = "-u"
+			if items[0] == "TCP" {
+				proto = "-t"
+			}
 			ipports := strings.Split(items[1], ":")
 			frontIp = strings.Join(ipports[0:len(ipports)-1], ":")
 			frontIp = strings.Trim(frontIp, "[")

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -111,6 +111,18 @@ func GetIpvsSchedulerTypeFromString(sch string) IpvsSchedulerType {
 	}
 }
 
+func getIpvsConnectionTypeFromForwardMode(forwardMode string) IpvsConnectionType {
+	switch strings.ToLower(forwardMode) {
+	case LB_FORWARD_MODE_FULL_NAT:
+		return IpvsConnectionTypeNAT
+	default:
+		// TODO(SUG-2795): add explicit nat/dr mappings when those forward
+		// modes are supported. Keep NAT as the current fallback for existing
+		// UDP IPVS listeners, which do not carry forwardMode.
+		return IpvsConnectionTypeNAT
+	}
+}
+
 func makeIpvsFirewallRuleDescription(lb LbInfo) string {
 	return fmt.Sprintf("%s-%v-%v", utils.IpvsComment, lb.LbUuid, lb.ListenerUuid)
 }
@@ -141,6 +153,40 @@ type IpvsFrontendService struct {
 	BackendServers map[string]*IpvsBackendServer
 	LbInfo
 	LbParams
+}
+
+func parseIpvsAclConfig(params []string) (string, []string, bool) {
+	var aclType string
+	var aclEntries []string
+	enableAcl := false
+	for _, param := range params {
+		parts := strings.SplitN(param, "::", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "accessControlStatus":
+			enableAcl = value == "enable"
+		case "aclType":
+			aclType = value
+		case "aclEntry":
+			for _, entry := range strings.Split(value, ",") {
+				entry = strings.TrimSpace(entry)
+				if entry != "" {
+					aclEntries = append(aclEntries, entry)
+				}
+			}
+		}
+	}
+
+	if !enableAcl || aclType == "" || len(aclEntries) == 0 {
+		return "", nil, false
+	}
+
+	return aclType, aclEntries, true
 }
 
 type IpvsConf struct {
@@ -319,6 +365,8 @@ func (ipvs *IpvsConf) ParseIpvs(content string) error {
 			info.LoadBalancerPort, _ = strconv.Atoi(port)
 			if protocol == "-u" {
 				info.Mode = "udp"
+			} else if protocol == "-t" {
+				info.Mode = "tcp"
 			}
 
 			param := LbParams{}
@@ -342,6 +390,22 @@ func (ipvs *IpvsConf) ParseIpvs(content string) error {
 			service.ConnectionType = items[5]
 			weight := items[7]
 			backend := NewIpvsBackendServer(backendIp, backendPort, weight, service)
+			for i := 8; i+1 < len(items); i++ {
+				switch items[i] {
+				case "-x":
+					value, err := strconv.Atoi(items[i+1])
+					if err != nil {
+						return fmt.Errorf("invalid ipvs max connection %q", items[i+1])
+					}
+					backend.maxConnection = value
+				case "-y":
+					value, err := strconv.Atoi(items[i+1])
+					if err != nil {
+						return fmt.Errorf("invalid ipvs min connection %q", items[i+1])
+					}
+					backend.minConnection = value
+				}
+			}
 			service.BackendServers[backend.GetBackendKey()] = backend
 		}
 	}
@@ -380,7 +444,7 @@ func NewIpvsBackendServer(serverIp, serverPort, weight string, frontService *Ipv
 }
 
 func NewIpvsFrontService(info LbInfo, param LbParams, frontIp string, servers map[string]*IpvsBackendServer) *IpvsFrontendService {
-	connectionType := IpvsConnectionTypeNAT.String()
+	connectionType := getIpvsConnectionTypeFromForwardMode(info.ForwardMode).String()
 	protocolType := "-u"
 	if info.Mode == LB_MODE_HTTPS || info.Mode == LB_MODE_HTTP || info.Mode == LB_MODE_TCP {
 		protocolType = "-t"
@@ -409,6 +473,238 @@ func NewIpvsConfFromSave() (*IpvsConf, error) {
 
 func (fs *IpvsFrontendService) getFrontendServiceKey() string {
 	return fs.ProtocolType + "-" + fs.FrontIp + "-" + fs.FrontPort
+}
+
+func validateIpvsAddress(address string) error {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return fmt.Errorf("invalid ipvs address %q", address)
+	}
+
+	return nil
+}
+
+func formatIpvsAddress(address string) string {
+	ip := net.ParseIP(address)
+	if ip.To4() == nil {
+		return fmt.Sprintf("[%s]", address)
+	}
+
+	return address
+}
+
+func validateIpvsPort(port string) error {
+	value, err := strconv.Atoi(port)
+	if err != nil || value <= 0 || value > 65535 {
+		return fmt.Errorf("invalid ipvs port %q", port)
+	}
+
+	return nil
+}
+
+func validateIpvsScheduler(scheduler string) error {
+	switch scheduler {
+	case IpvsSchedulerRR.String(), IpvsSchedulerWRR.String(), IpvsSchedulerLC.String(), IpvsSchedulerSH.String():
+		return nil
+	default:
+		return fmt.Errorf("invalid ipvs scheduler %q", scheduler)
+	}
+}
+
+func validateIpvsConnectionType(connectionType string) error {
+	switch connectionType {
+	case IpvsConnectionTypeDR.String(), IpvsConnectionTypeNAT.String(), IpvsConnectionTypeTUNNEL.String():
+		return nil
+	default:
+		return fmt.Errorf("invalid ipvs connection type %q", connectionType)
+	}
+}
+
+func validateIpvsWeight(weight string) error {
+	value, err := strconv.Atoi(weight)
+	if err != nil || value < 0 {
+		return fmt.Errorf("invalid ipvs weight %q", weight)
+	}
+
+	return nil
+}
+
+func ipvsProtocolArg(protocol string) string {
+	if strings.EqualFold(protocol, "tcp") || strings.EqualFold(protocol, "-t") {
+		return "-t"
+	}
+
+	return "-u"
+}
+
+func validateIpvsFrontendService(fs *IpvsFrontendService) error {
+	if err := validateIpvsAddress(fs.FrontIp); err != nil {
+		return err
+	}
+	if err := validateIpvsPort(fs.FrontPort); err != nil {
+		return err
+	}
+	if err := validateIpvsScheduler(fs.Scheduler); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateIpvsBackendServer(bs *IpvsBackendServer) error {
+	if err := validateIpvsFrontendService(bs.IpvsFrontendService); err != nil {
+		return err
+	}
+	if err := validateIpvsAddress(bs.BackendIp); err != nil {
+		return err
+	}
+	if err := validateIpvsPort(bs.BackendPort); err != nil {
+		return err
+	}
+	if err := validateIpvsConnectionType(bs.ConnectionType); err != nil {
+		return err
+	}
+	if err := validateIpvsWeight(bs.Weight); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fs *IpvsFrontendService) frontServiceAddress() string {
+	return fmt.Sprintf("%s:%s", formatIpvsAddress(fs.FrontIp), fs.FrontPort)
+}
+
+func (bs *IpvsBackendServer) backendAddress() string {
+	return fmt.Sprintf("%s:%s", formatIpvsAddress(bs.BackendIp), bs.BackendPort)
+}
+
+func makeIpvsAddServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -A %s %s -s %s", proto, fs.frontServiceAddress(), fs.Scheduler)
+}
+
+func makeIpvsEditServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -E %s %s -s %s", proto, fs.frontServiceAddress(), fs.Scheduler)
+}
+
+func makeIpvsDeleteServiceCommand(fs *IpvsFrontendService) string {
+	proto := ipvsProtocolArg(fs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -D %s %s", proto, fs.frontServiceAddress())
+}
+
+func makeIpvsAddBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -a %s %s -r %s %s -w %s -x %d -y %d",
+		proto, bs.frontServiceAddress(), bs.backendAddress(), bs.ConnectionType, bs.Weight,
+		bs.maxConnection, bs.minConnection)
+}
+
+func makeIpvsEditBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -e %s %s -r %s %s -w %s -x %d -y %d",
+		proto, bs.frontServiceAddress(), bs.backendAddress(), bs.ConnectionType, bs.Weight,
+		bs.maxConnection, bs.minConnection)
+}
+
+func makeIpvsDeleteBackendCommand(bs *IpvsBackendServer) string {
+	proto := ipvsProtocolArg(bs.ProtocolType)
+	return fmt.Sprintf("ipvsadm -d %s %s -r %s",
+		proto, bs.frontServiceAddress(), bs.backendAddress())
+}
+
+func sameIpvsBackend(current, desired *IpvsBackendServer) bool {
+	return current.ConnectionType == desired.ConnectionType &&
+		current.Weight == desired.Weight &&
+		current.maxConnection == desired.maxConnection &&
+		current.minConnection == desired.minConnection
+}
+
+func appendIpvsCommand(commands *[]string, cmd string) {
+	*commands = append(*commands, cmd)
+}
+
+func syncIpvsadm(oldConf, desiredConf *IpvsConf) error {
+	if desiredConf == nil {
+		desiredConf = &IpvsConf{Services: map[string]*IpvsFrontendService{}}
+	}
+	if oldConf == nil {
+		oldConf = &IpvsConf{Services: map[string]*IpvsFrontendService{}}
+	}
+
+	currentConf, err := NewIpvsConfFromSave()
+	if err != nil {
+		return err
+	}
+
+	var commands []string
+	for key, fs := range desiredConf.Services {
+		if err := validateIpvsFrontendService(fs); err != nil {
+			return err
+		}
+		current := currentConf.Services[key]
+		if current == nil {
+			appendIpvsCommand(&commands, makeIpvsAddServiceCommand(fs))
+		} else if current.Scheduler != fs.Scheduler {
+			appendIpvsCommand(&commands, makeIpvsEditServiceCommand(fs))
+		}
+
+		for backendKey, bs := range fs.BackendServers {
+			if err := validateIpvsBackendServer(bs); err != nil {
+				return err
+			}
+			currentBackend := (*IpvsBackendServer)(nil)
+			if current != nil {
+				currentBackend = current.BackendServers[backendKey]
+			}
+
+			if currentBackend == nil {
+				appendIpvsCommand(&commands, makeIpvsAddBackendCommand(bs))
+			} else if !sameIpvsBackend(currentBackend, bs) {
+				appendIpvsCommand(&commands, makeIpvsEditBackendCommand(bs))
+			}
+		}
+
+		if old := oldConf.Services[key]; old != nil && current != nil {
+			for backendKey, oldBackend := range old.BackendServers {
+				if _, ok := fs.BackendServers[backendKey]; !ok {
+					if current.BackendServers[backendKey] != nil {
+						if err := validateIpvsBackendServer(oldBackend); err != nil {
+							return err
+						}
+						appendIpvsCommand(&commands, makeIpvsDeleteBackendCommand(oldBackend))
+					}
+				}
+			}
+		}
+	}
+
+	for key, current := range currentConf.Services {
+		if _, ok := desiredConf.Services[key]; ok {
+			continue
+		}
+		if err := validateIpvsFrontendService(current); err != nil {
+			return err
+		}
+		appendIpvsCommand(&commands, makeIpvsDeleteServiceCommand(current))
+	}
+
+	if len(commands) == 0 {
+		return nil
+	}
+
+	b := utils.Bash{
+		Command: "set -e; " + strings.Join(commands, "; "),
+		Sudo:    true,
+	}
+	ret, stdout, stderr, err := b.RunWithReturn()
+	if ret != 0 || err != nil {
+		return fmt.Errorf("failed to sync ipvsadm, ret: %d, stdout: %s, stderr: %s, error: %v",
+			ret, stdout, stderr, err)
+	}
+
+	return nil
 }
 
 func (fs *IpvsFrontendService) EnableIpvsLog() (err error) {
@@ -692,36 +988,13 @@ func RefreshIpvsBackend() error {
 	services := map[string]*IpvsFrontendService{}
 	for _, lb := range gIpvsLbInfoMap {
 		for _, listener := range lb {
-			if strings.ToLower(listener.Mode) != "udp" {
-				/* current only udp lb use ipvs */
+			if !isIpvsDataPlane(listener) {
 				continue
 			}
 
 			lbParam := ParseLbParams(listener)
 
-			// parse ACL config
-			var aclType string
-			var aclEntries []string
-			enableAcl := false
-			for _, param := range listener.Parameters {
-				parts := strings.Split(param, "::")
-				if len(parts) != 2 {
-					continue
-				}
-
-				switch parts[0] {
-				case "accessControlStatus":
-					// Acl are processed only when accessControlStatus is enabled
-					if parts[1] == "enable" {
-						enableAcl = true
-					}
-				case "aclType":
-					aclType = parts[1]
-				case "aclEntry":
-					// If multiple IP addresses are separated by commas (,), split them
-					aclEntries = strings.Split(parts[1], ",")
-				}
-			}
+			aclType, aclEntries, enableAcl := parseIpvsAclConfig(listener.Parameters)
 
 			var fs4, fs6 *IpvsFrontendService
 			if listener.Vip != "" {
@@ -764,7 +1037,13 @@ func RefreshIpvsBackend() error {
 		}
 	}
 
-	gIpvsConf = &IpvsConf{Services: services}
+	desiredConf := &IpvsConf{Services: services}
+	err := syncIpvsadm(gIpvsConf, desiredConf)
+	if err != nil {
+		return err
+	}
+
+	gIpvsConf = desiredConf
 	gIpvsConf.ReloadIpvsHealthCheckConfig()
 
 	if utils.IsSkipVyosIptables() {

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -692,8 +692,7 @@ func RefreshIpvsBackend() error {
 	services := map[string]*IpvsFrontendService{}
 	for _, lb := range gIpvsLbInfoMap {
 		for _, listener := range lb {
-			if strings.ToLower(listener.Mode) != "udp" {
-				/* current only udp lb use ipvs */
+			if !isIpvsDataPlane(listener) {
 				continue
 			}
 

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -1183,10 +1183,10 @@ func UpdateIpvsMetrics(c *loadBalancerCollector, ch chan<- prom.Metric) (err err
 			ch <- prom.MustNewConstMetric(c.statusEntry, prom.GaugeValue, float64(cnt.Status), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
 			ch <- prom.MustNewConstMetric(c.inByteEntry, prom.GaugeValue, float64(cnt.bytesIn), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
 			ch <- prom.MustNewConstMetric(c.outByteEntry, prom.GaugeValue, float64(cnt.bytesOut), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
-			ch <- prom.MustNewConstMetric(c.curSessionNumEntry, prom.GaugeValue, float64(cnt.sessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid)
-			ch <- prom.MustNewConstMetric(c.refusedSessionNumEntry, prom.GaugeValue, float64(cnt.refusedSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid)
-			ch <- prom.MustNewConstMetric(c.totalSessionNumEntry, prom.GaugeValue, float64(cnt.totalSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid)
-			ch <- prom.MustNewConstMetric(c.concurrentSessionUsageEntry, prom.GaugeValue, float64(cnt.concurrentSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid)
+			ch <- prom.MustNewConstMetric(c.curSessionNumEntry, prom.GaugeValue, float64(cnt.sessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
+			ch <- prom.MustNewConstMetric(c.refusedSessionNumEntry, prom.GaugeValue, float64(cnt.refusedSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
+			ch <- prom.MustNewConstMetric(c.totalSessionNumEntry, prom.GaugeValue, float64(cnt.totalSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
+			ch <- prom.MustNewConstMetric(c.concurrentSessionUsageEntry, prom.GaugeValue, float64(cnt.concurrentSessionNumber), cnt.listenerUuid, cnt.ip, cnt.lbUuid, cnt.serverGroupUuid)
 		}
 		if maxConnection > 0 {
 			ch <- prom.MustNewConstMetric(c.curSessionUsageEntry, prom.GaugeValue, float64(fs.SessionNumber*100/(uint64)(maxConnection)), fs.ListenerUuid, fs.LbUuid)
@@ -1197,13 +1197,7 @@ func UpdateIpvsMetrics(c *loadBalancerCollector, ch chan<- prom.Metric) (err err
 }
 
 func UpdateIpvsCounters() {
-	for _, fs := range gIpvsConf.Services {
-		for _, bs := range fs.BackendServers {
-			/* if it can not be updated by ipvsadm -L -n --stats, it's down*/
-			bs.Counter.ip = bs.BackendIp
-			bs.Counter.Status = 0
-		}
-	}
+	resetIpvsCounters()
 
 	b := utils.Bash{
 		/*
@@ -1224,55 +1218,8 @@ func UpdateIpvsCounters() {
 	}
 
 	ret, o, _, err := b.RunWithReturn()
-	if ret != 0 || err != nil {
-		return
-	}
-
-	frontIp := ""
-	frontPort := ""
-	proto := "-u"
-	backendIp := ""
-	backendPort := ""
-	lines := strings.Split(o, "\n")
-	lines = lines[3:] //ignore the first 3 lines
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || len(line) == 0 {
-			continue
-		}
-		items := strings.Fields(line)
-		if items[0] == "TCP" || items[0] == "UDP" {
-			proto = "-u"
-			if items[0] == "TCP" {
-				proto = "-t"
-			}
-			ipports := strings.Split(items[1], ":")
-			frontIp = strings.Join(ipports[0:len(ipports)-1], ":")
-			frontIp = strings.Trim(frontIp, "[")
-			frontIp = strings.Trim(frontIp, "]")
-			frontPort = ipports[len(ipports)-1]
-		} else if items[0] == "->" {
-			ipports := strings.Split(items[1], ":")
-			backendIp = strings.Join(ipports[0:len(ipports)-1], ":")
-			backendIp = strings.Trim(backendIp, "[")
-			backendIp = strings.Trim(backendIp, "]")
-			backendPort = ipports[len(ipports)-1]
-
-			bs := getIpvsBackend(proto, frontIp, frontPort, backendIp, backendPort)
-			if bs == nil {
-				log.Debugf("GetIpvsCounters backend server for key:%s:%s:%s:%s:%s not found",
-					proto, frontIp, frontPort, backendIp, backendPort)
-				break
-			}
-
-			bs.Counter.ip = backendIp
-			bs.Counter.Status = 1
-			bs.Counter.bytesIn, _ = strconv.ParseUint(strings.Trim(items[5], " "), 10, 64)
-			bs.Counter.bytesOut, _ = strconv.ParseUint(strings.Trim(items[6], " "), 10, 64)
-		} else {
-			frontIp = ""
-			frontPort = ""
-		}
+	if ret == 0 && err == nil {
+		updateIpvsCountersFromStats(o)
 	}
 
 	b = utils.Bash{
@@ -1292,11 +1239,35 @@ func UpdateIpvsCounters() {
 	}
 
 	ret, o, _, err = b.RunWithReturn()
-	if ret != 0 || err != nil {
-		return
+	if ret == 0 && err == nil {
+		updateIpvsCountersFromThresholds(o)
 	}
-	lines = strings.Split(o, "\n")
-	lines = lines[3:] //ignore the first 3 lines
+}
+
+func resetIpvsCounters() {
+	for _, fs := range gIpvsConf.Services {
+		for _, bs := range fs.BackendServers {
+			/* if it can not be updated by ipvsadm -L -n --stats, it's down*/
+			bs.Counter.ip = bs.BackendIp
+			bs.Counter.Status = 0
+			bs.Counter.bytesIn = 0
+			bs.Counter.bytesOut = 0
+			bs.Counter.sessionNumber = 0
+			bs.Counter.refusedSessionNumber = 0
+			bs.Counter.totalSessionNumber = 0
+			bs.Counter.concurrentSessionNumber = 0
+		}
+	}
+
+}
+
+func updateIpvsCountersFromStats(output string) {
+	frontIp := ""
+	frontPort := ""
+	proto := "-u"
+	backendIp := ""
+	backendPort := ""
+	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || len(line) == 0 {
@@ -1304,17 +1275,29 @@ func UpdateIpvsCounters() {
 		}
 		items := strings.Fields(line)
 		if items[0] == "TCP" || items[0] == "UDP" {
+			if len(items) < 2 {
+				continue
+			}
 			proto = "-u"
 			if items[0] == "TCP" {
 				proto = "-t"
 			}
 			ipports := strings.Split(items[1], ":")
+			if len(ipports) < 2 {
+				continue
+			}
 			frontIp = strings.Join(ipports[0:len(ipports)-1], ":")
 			frontIp = strings.Trim(frontIp, "[")
 			frontIp = strings.Trim(frontIp, "]")
 			frontPort = ipports[len(ipports)-1]
 		} else if items[0] == "->" {
+			if len(items) < 7 {
+				continue
+			}
 			ipports := strings.Split(items[1], ":")
+			if len(ipports) < 2 {
+				continue
+			}
 			backendIp = strings.Join(ipports[0:len(ipports)-1], ":")
 			backendIp = strings.Trim(backendIp, "[")
 			backendIp = strings.Trim(backendIp, "]")
@@ -1324,9 +1307,71 @@ func UpdateIpvsCounters() {
 			if bs == nil {
 				log.Debugf("GetIpvsCounters backend server for key:%s:%s:%s:%s:%s not found",
 					proto, frontIp, frontPort, backendIp, backendPort)
-				break
+				continue
 			}
 
+			bs.Counter.ip = backendIp
+			bs.Counter.Status = 1
+			bs.Counter.bytesIn, _ = strconv.ParseUint(strings.Trim(items[5], " "), 10, 64)
+			bs.Counter.bytesOut, _ = strconv.ParseUint(strings.Trim(items[6], " "), 10, 64)
+		} else {
+			frontIp = ""
+			frontPort = ""
+		}
+	}
+}
+
+func updateIpvsCountersFromThresholds(output string) {
+	frontIp := ""
+	frontPort := ""
+	proto := "-u"
+	backendIp := ""
+	backendPort := ""
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || len(line) == 0 {
+			continue
+		}
+		items := strings.Fields(line)
+		if items[0] == "TCP" || items[0] == "UDP" {
+			if len(items) < 2 {
+				continue
+			}
+			proto = "-u"
+			if items[0] == "TCP" {
+				proto = "-t"
+			}
+			ipports := strings.Split(items[1], ":")
+			if len(ipports) < 2 {
+				continue
+			}
+			frontIp = strings.Join(ipports[0:len(ipports)-1], ":")
+			frontIp = strings.Trim(frontIp, "[")
+			frontIp = strings.Trim(frontIp, "]")
+			frontPort = ipports[len(ipports)-1]
+		} else if items[0] == "->" {
+			if len(items) < 6 {
+				continue
+			}
+			ipports := strings.Split(items[1], ":")
+			if len(ipports) < 2 {
+				continue
+			}
+			backendIp = strings.Join(ipports[0:len(ipports)-1], ":")
+			backendIp = strings.Trim(backendIp, "[")
+			backendIp = strings.Trim(backendIp, "]")
+			backendPort = ipports[len(ipports)-1]
+
+			bs := getIpvsBackend(proto, frontIp, frontPort, backendIp, backendPort)
+			if bs == nil {
+				log.Debugf("GetIpvsCounters backend server for key:%s:%s:%s:%s:%s not found",
+					proto, frontIp, frontPort, backendIp, backendPort)
+				continue
+			}
+
+			bs.Counter.ip = backendIp
+			bs.Counter.Status = 1
 			bs.Counter.sessionNumber, _ = strconv.ParseUint(strings.Trim(items[4], " "), 10, 64)
 			bs.Counter.concurrentSessionNumber = bs.Counter.sessionNumber
 			bs.Counter.refusedSessionNumber, _ = strconv.ParseUint(strings.Trim(items[5], " "), 10, 64)

--- a/plugin/ipvs.go
+++ b/plugin/ipvs.go
@@ -143,6 +143,38 @@ type IpvsFrontendService struct {
 	LbParams
 }
 
+func parseIpvsAclConfig(params []string) (string, []string, bool) {
+	var aclType string
+	var aclEntries []string
+	enableAcl := false
+	for _, param := range params {
+		parts := strings.Split(param, "::")
+		if len(parts) != 2 {
+			continue
+		}
+
+		switch parts[0] {
+		case "accessControlStatus":
+			enableAcl = parts[1] == "enable"
+		case "aclType":
+			aclType = parts[1]
+		case "aclEntry":
+			for _, entry := range strings.Split(parts[1], ",") {
+				entry = strings.TrimSpace(entry)
+				if entry != "" {
+					aclEntries = append(aclEntries, entry)
+				}
+			}
+		}
+	}
+
+	if !enableAcl || aclType == "" || len(aclEntries) == 0 {
+		return "", nil, false
+	}
+
+	return aclType, aclEntries, true
+}
+
 type IpvsConf struct {
 	Services map[string]*IpvsFrontendService
 }
@@ -522,7 +554,7 @@ func refreshIpvsFirewallRuleByVyos(services map[string]*IpvsFrontendService) err
 			}
 		}
 		if fs.AclType != "" && len(fs.AclEntry) > 0 {
-			err := fmt.Errorf("can not set UDP Load Balancer ACL on VyOS;please upgrade to ZStack Euler VRouter image")
+			err := fmt.Errorf("can not set IPVS Load Balancer ACL on VyOS;please upgrade to ZStack Euler VRouter image")
 			utils.PanicOnError(err)
 		}
 	}
@@ -698,29 +730,7 @@ func RefreshIpvsBackend() error {
 
 			lbParam := ParseLbParams(listener)
 
-			// parse ACL config
-			var aclType string
-			var aclEntries []string
-			enableAcl := false
-			for _, param := range listener.Parameters {
-				parts := strings.Split(param, "::")
-				if len(parts) != 2 {
-					continue
-				}
-
-				switch parts[0] {
-				case "accessControlStatus":
-					// Acl are processed only when accessControlStatus is enabled
-					if parts[1] == "enable" {
-						enableAcl = true
-					}
-				case "aclType":
-					aclType = parts[1]
-				case "aclEntry":
-					// If multiple IP addresses are separated by commas (,), split them
-					aclEntries = strings.Split(parts[1], ",")
-				}
-			}
+			aclType, aclEntries, enableAcl := parseIpvsAclConfig(listener.Parameters)
 
 			var fs4, fs6 *IpvsFrontendService
 			if listener.Vip != "" {

--- a/plugin/ipvs_acl_test.go
+++ b/plugin/ipvs_acl_test.go
@@ -1,0 +1,114 @@
+package plugin
+
+import (
+	"reflect"
+	"testing"
+	"zstack-vyos/utils"
+)
+
+func TestParseIpvsAclConfigMatchesUdpEmptyEntrySemantics(t *testing.T) {
+	aclType, aclEntries, enabled := parseIpvsAclConfig([]string{
+		"accessControlStatus::enable",
+		"aclType::black",
+		"aclEntry::",
+	})
+
+	if enabled {
+		t.Fatalf("empty aclEntry must not enable ipvs acl, got type=%q entries=%v", aclType, aclEntries)
+	}
+}
+
+func TestParseIpvsAclConfigTrimsEntries(t *testing.T) {
+	aclType, aclEntries, enabled := parseIpvsAclConfig([]string{
+		"accessControlStatus::enable",
+		"aclType::white",
+		"aclEntry:: 10.0.0.10/32, ,10.0.0.20-10.0.0.30 ",
+	})
+
+	if !enabled {
+		t.Fatal("expected non-empty acl entries to enable ipvs acl")
+	}
+	if aclType != "white" {
+		t.Fatalf("unexpected acl type: %s", aclType)
+	}
+	expected := []string{"10.0.0.10/32", "10.0.0.20-10.0.0.30"}
+	if !reflect.DeepEqual(expected, aclEntries) {
+		t.Fatalf("unexpected acl entries: %v", aclEntries)
+	}
+}
+
+func TestTcpIpvsAclRulesMatchUdpAclSemantics(t *testing.T) {
+	fs := &IpvsFrontendService{
+		FrontIp:   "172.24.7.153",
+		FrontPort: "19086",
+		AclType:   "white",
+		AclEntry:  []string{"10.0.0.10/32", "10.0.0.20-10.0.0.30"},
+	}
+	table := &utils.IpTables{Name: utils.FirewallTable}
+
+	rules := addAclRules(table, fs, "eth1", utils.IPTABLES_PROTO_TCP)
+
+	if !table.CheckChain("acl-rules@eth1@19086") {
+		t.Fatal("expected tcp ipvs acl chain to be created")
+	}
+	if len(rules) != 5 {
+		t.Fatalf("expected jump, two allow rules, default reject and return, got %d", len(rules))
+	}
+
+	jump := rules[0]
+	if jump.GetChainName() != "eth1.local" || jump.GetAction() != "acl-rules@eth1@19086" {
+		t.Fatalf("unexpected tcp acl jump rule: %s", jump.String())
+	}
+	if jump.GetProto() != utils.IPTABLES_PROTO_TCP || jump.GetDstPort() != "19086" {
+		t.Fatalf("tcp acl jump rule must match tcp frontend port: %s", jump.String())
+	}
+
+	firstAllow := rules[1]
+	if firstAllow.GetAction() != utils.IPTABLES_ACTION_ACCEPT ||
+		firstAllow.GetProto() != utils.IPTABLES_PROTO_TCP ||
+		firstAllow.GetDstIp() != "172.24.7.153" ||
+		firstAllow.GetDstPort() != "19086" ||
+		firstAllow.GetSrcIp() != "10.0.0.10/32" {
+		t.Fatalf("unexpected tcp whitelist allow rule: %s", firstAllow.String())
+	}
+
+	rangeAllow := rules[2]
+	if rangeAllow.GetAction() != utils.IPTABLES_ACTION_ACCEPT ||
+		rangeAllow.GetSrcIpRange() != "10.0.0.20-10.0.0.30" {
+		t.Fatalf("unexpected tcp whitelist range rule: %s", rangeAllow.String())
+	}
+
+	defaultReject := rules[3]
+	if defaultReject.GetAction() != utils.IPTABLES_ACTION_REJECT ||
+		defaultReject.GetRejectType() != utils.REJECT_TYPE_ICMP_UNREACHABLE {
+		t.Fatalf("tcp whitelist must reject unmatched sources: %s", defaultReject.String())
+	}
+
+	if rules[4].GetAction() != utils.IPTABLES_ACTION_RETURN {
+		t.Fatalf("expected tcp acl chain to end with return: %s", rules[4].String())
+	}
+}
+
+func TestTcpIpvsBlacklistRejectsMatchedSources(t *testing.T) {
+	fs := &IpvsFrontendService{
+		FrontIp:   "172.24.7.153",
+		FrontPort: "19086",
+		AclType:   "black",
+		AclEntry:  []string{"10.0.0.10/32"},
+	}
+	table := &utils.IpTables{Name: utils.FirewallTable}
+
+	rules := addAclRules(table, fs, "eth1", utils.IPTABLES_PROTO_TCP)
+
+	if len(rules) != 3 {
+		t.Fatalf("expected jump, reject and return, got %d", len(rules))
+	}
+
+	reject := rules[1]
+	if reject.GetAction() != utils.IPTABLES_ACTION_REJECT ||
+		reject.GetRejectType() != utils.REJECT_TYPE_ICMP_UNREACHABLE ||
+		reject.GetProto() != utils.IPTABLES_PROTO_TCP ||
+		reject.GetSrcIp() != "10.0.0.10/32" {
+		t.Fatalf("unexpected tcp blacklist reject rule: %s", reject.String())
+	}
+}

--- a/plugin/ipvs_sync_test.go
+++ b/plugin/ipvs_sync_test.go
@@ -1,0 +1,153 @@
+package plugin
+
+import "testing"
+
+func TestIpvsCommandBuildersUseTcpFullNatBackendPort(t *testing.T) {
+	lb := LbInfo{
+		LbUuid:           "lb",
+		ListenerUuid:     "listener",
+		Vip:              "172.24.7.153",
+		LoadBalancerPort: 19086,
+		InstancePort:     8080,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+		Parameters:       []string{"balancerAlgorithm::roundrobin"},
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip, map[string]*IpvsBackendServer{})
+	bs := NewIpvsBackendServer("192.168.10.20", "8080", "100", fs)
+
+	if got, want := makeIpvsAddServiceCommand(fs), "ipvsadm -A -t 172.24.7.153:19086 -s rr"; got != want {
+		t.Fatalf("unexpected add service command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsAddBackendCommand(bs), "ipvsadm -a -t 172.24.7.153:19086 -r 192.168.10.20:8080 -m -w 100 -x 0 -y 0"; got != want {
+		t.Fatalf("unexpected add backend command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsDeleteServiceCommand(fs), "ipvsadm -D -t 172.24.7.153:19086"; got != want {
+		t.Fatalf("unexpected delete service command:\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestTcpIpvsListenerIsRoutedToIpvsDataPlane(t *testing.T) {
+	lb := LbInfo{
+		Mode:        LB_MODE_TCP,
+		DataPlane:   LB_DATA_PLANE_IPVS,
+		ForwardMode: LB_FORWARD_MODE_FULL_NAT,
+	}
+
+	if !isIpvsListener(lb) {
+		t.Fatal("expected tcp ipvs full_nat listener to use ipvs path")
+	}
+
+	lb.DataPlane = ""
+	lb.ForwardMode = ""
+	if isIpvsListener(lb) {
+		t.Fatal("expected default tcp listener to stay on haproxy path")
+	}
+}
+
+func TestIpvsCommandBuildersQuoteIPv6Address(t *testing.T) {
+	lb := LbInfo{
+		LbUuid:           "lb",
+		ListenerUuid:     "listener",
+		Vip6:             "2001:db8::10",
+		LoadBalancerPort: 19086,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+		Parameters:       []string{"balancerAlgorithm::rr"},
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip6, map[string]*IpvsBackendServer{})
+	bs := NewIpvsBackendServer("2001:db8::20", "8080", "1", fs)
+
+	if got, want := makeIpvsAddServiceCommand(fs), "ipvsadm -A -t [2001:db8::10]:19086 -s rr"; got != want {
+		t.Fatalf("unexpected ipv6 add service command:\nwant: %s\n got: %s", want, got)
+	}
+	if got, want := makeIpvsDeleteBackendCommand(bs), "ipvsadm -d -t [2001:db8::10]:19086 -r [2001:db8::20]:8080"; got != want {
+		t.Fatalf("unexpected ipv6 delete backend command:\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestIpvsCommandBuildersRejectInvalidAddress(t *testing.T) {
+	lb := LbInfo{
+		Vip:              "172.24.7.153;touch /tmp/pwned",
+		LoadBalancerPort: 19086,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip, map[string]*IpvsBackendServer{})
+
+	if err := validateIpvsFrontendService(fs); err == nil {
+		t.Fatal("expected invalid frontend address to be rejected")
+	}
+}
+
+func TestSameIpvsBackendComparesConnectionLimits(t *testing.T) {
+	current := &IpvsBackendServer{
+		ConnectionType: "-m",
+		Weight:         "100",
+		maxConnection:  10,
+		minConnection:  1,
+	}
+	desired := &IpvsBackendServer{
+		ConnectionType: "-m",
+		Weight:         "100",
+		maxConnection:  20,
+		minConnection:  1,
+	}
+
+	if sameIpvsBackend(current, desired) {
+		t.Fatal("expected maxConnection change to require backend edit")
+	}
+}
+
+func TestParseIpvsKeepsBackendConnectionLimits(t *testing.T) {
+	conf := &IpvsConf{}
+	err := conf.ParseIpvs(`
+-A -t 172.24.7.153:19086 -s rr
+-a -t 172.24.7.153:19086 -r 192.168.10.20:8080 -m -w 100 -x 20 -y 3
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service := conf.Services["-t-172.24.7.153-19086"]
+	if service == nil {
+		t.Fatal("expected parsed service")
+	}
+	backend := service.BackendServers["192.168.10.20-8080"]
+	if backend == nil {
+		t.Fatal("expected parsed backend")
+	}
+	if backend.maxConnection != 20 || backend.minConnection != 3 {
+		t.Fatalf("unexpected connection limits: max=%d min=%d", backend.maxConnection, backend.minConnection)
+	}
+}
+
+func TestIpvsConnectionTypeFollowsForwardMode(t *testing.T) {
+	if got := getIpvsConnectionTypeFromForwardMode(LB_FORWARD_MODE_FULL_NAT); got != IpvsConnectionTypeNAT {
+		t.Fatalf("unexpected full_nat connection type: %s", got.String())
+	}
+}
+
+func TestParseIpvsAclConfigKeepsIPv6Entries(t *testing.T) {
+	aclType, entries, enabled := parseIpvsAclConfig([]string{
+		"accessControlStatus::enable",
+		"aclType::white",
+		"aclEntry::2001:db8::1/128, 192.168.10.0/24",
+	})
+
+	if !enabled {
+		t.Fatal("expected acl to be enabled")
+	}
+	if aclType != "white" {
+		t.Fatalf("unexpected acl type: %s", aclType)
+	}
+	if len(entries) != 2 || entries[0] != "2001:db8::1/128" || entries[1] != "192.168.10.0/24" {
+		t.Fatalf("unexpected acl entries: %#v", entries)
+	}
+}

--- a/plugin/ipvs_sync_test.go
+++ b/plugin/ipvs_sync_test.go
@@ -1,6 +1,10 @@
 package plugin
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestIpvsCommandBuildersUseTcpFullNatBackendPort(t *testing.T) {
 	lb := LbInfo{
@@ -90,14 +94,22 @@ func TestSameIpvsBackendComparesConnectionLimits(t *testing.T) {
 	current := &IpvsBackendServer{
 		ConnectionType: "-m",
 		Weight:         "100",
-		maxConnection:  10,
-		minConnection:  1,
+		IpvsFrontendService: &IpvsFrontendService{
+			LbParams: LbParams{
+				maxConnection: 10,
+				minConnection: 1,
+			},
+		},
 	}
 	desired := &IpvsBackendServer{
 		ConnectionType: "-m",
 		Weight:         "100",
-		maxConnection:  20,
-		minConnection:  1,
+		IpvsFrontendService: &IpvsFrontendService{
+			LbParams: LbParams{
+				maxConnection: 20,
+				minConnection: 1,
+			},
+		},
 	}
 
 	if sameIpvsBackend(current, desired) {
@@ -149,5 +161,113 @@ func TestParseIpvsAclConfigKeepsIPv6Entries(t *testing.T) {
 	}
 	if len(entries) != 2 || entries[0] != "2001:db8::1/128" || entries[1] != "192.168.10.0/24" {
 		t.Fatalf("unexpected acl entries: %#v", entries)
+	}
+}
+
+func TestTcpIpvsCountersUseTcpKeyAndKeepDesiredMissingActualDown(t *testing.T) {
+	oldConf := gIpvsConf
+	defer func() {
+		gIpvsConf = oldConf
+	}()
+
+	lb := LbInfo{
+		LbUuid:           "lb",
+		ListenerUuid:     "listener",
+		Vip:              "172.24.7.153",
+		LoadBalancerPort: 19086,
+		InstancePort:     8080,
+		Mode:             LB_MODE_TCP,
+		DataPlane:        LB_DATA_PLANE_IPVS,
+		ForwardMode:      LB_FORWARD_MODE_FULL_NAT,
+		ServerGroups: []ServerGroupInfo{
+			{
+				ServerGroupUuid: "sg",
+				BackendServers: []BackendServerInfo{
+					{Ip: "192.168.10.20", Weight: 100},
+					{Ip: "192.168.10.21", Weight: 100},
+				},
+			},
+		},
+	}
+	param := ParseLbParams(lb)
+	fs := NewIpvsFrontService(lb, param, lb.Vip, map[string]*IpvsBackendServer{})
+	upBackend := NewIpvsBackendServer("192.168.10.20", "8080", "100", fs)
+	downBackend := NewIpvsBackendServer("192.168.10.21", "8080", "100", fs)
+	fs.BackendServers[upBackend.GetBackendKey()] = upBackend
+	fs.BackendServers[downBackend.GetBackendKey()] = downBackend
+	gIpvsConf = &IpvsConf{Services: map[string]*IpvsFrontendService{
+		fs.getFrontendServiceKey(): fs,
+	}}
+
+	resetIpvsCounters()
+	updateIpvsCountersFromStats(`
+IP Virtual Server version 1.2.1 (size=4096)
+Prot LocalAddress:Port               Conns   InPkts  OutPkts  InBytes OutBytes
+  -> RemoteAddress:Port
+TCP  172.24.7.153:19086                  0        0        0        0        0
+  -> 192.168.10.20:8080                  0        0        0      123      456
+`)
+	updateIpvsCountersFromThresholds(`
+IP Virtual Server version 1.2.1 (size=4096)
+Prot LocalAddress:Port            Uthreshold Lthreshold ActiveConn InActConn
+  -> RemoteAddress:Port
+TCP  172.24.7.153:19086 rr
+  -> 192.168.10.20:8080             0          0          7          2
+`)
+
+	if upBackend.Counter.Status != 1 {
+		t.Fatalf("expected actual TCP backend to be up, got %d", upBackend.Counter.Status)
+	}
+	if upBackend.Counter.bytesIn != 123 || upBackend.Counter.bytesOut != 456 {
+		t.Fatalf("unexpected traffic counters: in=%d out=%d", upBackend.Counter.bytesIn, upBackend.Counter.bytesOut)
+	}
+	if upBackend.Counter.sessionNumber != 7 || upBackend.Counter.refusedSessionNumber != 2 || upBackend.Counter.totalSessionNumber != 9 {
+		t.Fatalf("unexpected session counters: active=%d refused=%d total=%d",
+			upBackend.Counter.sessionNumber, upBackend.Counter.refusedSessionNumber, upBackend.Counter.totalSessionNumber)
+	}
+	if downBackend.Counter.Status != 0 {
+		t.Fatalf("expected desired backend missing from actual IPVS to stay down, got %d", downBackend.Counter.Status)
+	}
+
+	resetIpvsCounters()
+	updateIpvsCountersFromStats(`
+IP Virtual Server version 1.2.1 (size=4096)
+Prot LocalAddress:Port               Conns   InPkts  OutPkts  InBytes OutBytes
+  -> RemoteAddress:Port
+TCP  172.24.7.153:19086                  0        0        0        0        0
+`)
+	if upBackend.Counter.Status != 0 {
+		t.Fatalf("expected missing TCP backend to be reset down, got %d", upBackend.Counter.Status)
+	}
+	if upBackend.Counter.bytesIn != 0 || upBackend.Counter.bytesOut != 0 ||
+		upBackend.Counter.sessionNumber != 0 || upBackend.Counter.refusedSessionNumber != 0 ||
+		upBackend.Counter.totalSessionNumber != 0 || upBackend.Counter.concurrentSessionNumber != 0 {
+		t.Fatalf("expected missing TCP backend counters to reset, got %+v", upBackend.Counter)
+	}
+
+	resetIpvsCounters()
+	updateIpvsCountersFromThresholds(`
+IP Virtual Server version 1.2.1 (size=4096)
+Prot LocalAddress:Port            Uthreshold Lthreshold ActiveConn InActConn
+  -> RemoteAddress:Port
+TCP  172.24.7.153:19086 rr
+  -> 192.168.10.20:8080             0          0          3          1
+`)
+	if upBackend.Counter.Status != 1 {
+		t.Fatalf("expected thresholds parser to mark actual TCP backend up, got %d", upBackend.Counter.Status)
+	}
+}
+
+func TestLbSessionMetricsExposeServerGroupUuidLabel(t *testing.T) {
+	collector := NewLbPrometheusCollector().(*loadBalancerCollector)
+	for name, desc := range map[string]string{
+		"cur":        fmt.Sprint(collector.curSessionNumEntry),
+		"refused":    fmt.Sprint(collector.refusedSessionNumEntry),
+		"total":      fmt.Sprint(collector.totalSessionNumEntry),
+		"concurrent": fmt.Sprint(collector.concurrentSessionUsageEntry),
+	} {
+		if !strings.Contains(desc, LB_ServerGroup_UUID) {
+			t.Fatalf("expected %s session metric to expose %s label: %s", name, LB_ServerGroup_UUID, desc)
+		}
 	}
 }

--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -42,6 +42,9 @@ const (
 	LB_MODE_TCP   = "tcp"
 	LB_MODE_UDP   = "udp"
 
+	LB_DATA_PLANE_IPVS       = "ipvs"
+	LB_FORWARD_MODE_FULL_NAT = "full_nat"
+
 	LB_BACKEND_PREFIX_REG = "^nic-"
 
 	LISTENER_MAP_SIZE = 128
@@ -142,6 +145,8 @@ type LbInfo struct {
 	InstancePort       int                `json:"instancePort"`
 	LoadBalancerPort   int                `json:"loadBalancerPort"`
 	Mode               string             `json:"mode"`
+	DataPlane          string             `json:"dataPlane"`
+	ForwardMode        string             `json:"forwardMode"`
 	Parameters         []string           `json:"parameters"`
 	CertificateUuid    string             `json:"certificateUuid"`
 	SecurityPolicyType string             `json:"securityPolicyType"`
@@ -250,6 +255,22 @@ func ParseLbParams(lb LbInfo) LbParams {
 	}
 
 	return param
+}
+
+func isIpvsDataPlane(info LbInfo) bool {
+	if info.Mode == LB_MODE_UDP {
+		return true
+	}
+
+	if info.Mode != LB_MODE_TCP {
+		return false
+	}
+
+	return strings.EqualFold(info.DataPlane, LB_DATA_PLANE_IPVS) && strings.EqualFold(info.ForwardMode, LB_FORWARD_MODE_FULL_NAT)
+}
+
+func isTcpIpvsDataPlane(info LbInfo) bool {
+	return info.Mode == LB_MODE_TCP && strings.EqualFold(info.DataPlane, LB_DATA_PLANE_IPVS) && strings.EqualFold(info.ForwardMode, LB_FORWARD_MODE_FULL_NAT)
 }
 
 type Listener interface {
@@ -2175,8 +2196,12 @@ func AddLbs(lbs []Listener) error {
 }
 
 func isIpvsListener(info LbInfo) bool {
-	if info.Mode != LB_MODE_UDP {
+	if !isIpvsDataPlane(info) {
 		return false
+	}
+
+	if isTcpIpvsDataPlane(info) {
+		return true
 	}
 
 	confPath := makeLbConfFilePath(info)
@@ -2265,6 +2290,14 @@ func DeleteLbInternal(cmd *deleteLbCmd) {
 	ipvs := map[string]LbInfo{}
 	if len(cmd.Lbs) > 0 {
 		for _, lb := range cmd.Lbs {
+			if isTcpIpvsDataPlane(lb) {
+				if listener := GetListener(lb); listener != nil {
+					toDeleted = append(toDeleted, listener)
+				}
+				ipvs[lb.ListenerUuid] = lb
+				continue
+			}
+
 			if isIpvsListener(lb) {
 				ipvs[lb.ListenerUuid] = lb
 				continue

--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -2220,9 +2220,7 @@ func RefreshLbInternal(cmd *RefreshLbCmd) {
 			if listener != nil {
 				toDeleted = append(toDeleted, listener)
 			}
-			if len(lb.NicIps) != 0 {
-				ipvsAdded[lb.ListenerUuid] = lb
-			}
+			ipvsAdded[lb.ListenerUuid] = lb
 			continue
 		}
 

--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -186,6 +186,7 @@ type LbParams struct {
 	httpRedirectHttps     bool
 	accessControlStatus   bool
 	balancerAlgorithm     string
+	dataPlane             string
 	aclEntry              []string
 }
 
@@ -246,10 +247,28 @@ func ParseLbParams(lb LbInfo) LbParams {
 			}
 		case "balancerAlgorithm":
 			param.balancerAlgorithm = kv[1]
+		case "dataPlane":
+			param.dataPlane = kv[1]
 		}
 	}
 
 	return param
+}
+
+func isIpvsDataPlane(info LbInfo) bool {
+	if info.Mode == LB_MODE_UDP {
+		return true
+	}
+
+	if info.Mode != LB_MODE_TCP {
+		return false
+	}
+
+	return strings.EqualFold(ParseLbParams(info).dataPlane, "ipvs")
+}
+
+func isTcpIpvsDataPlane(info LbInfo) bool {
+	return info.Mode == LB_MODE_TCP && strings.EqualFold(ParseLbParams(info).dataPlane, "ipvs")
 }
 
 type Listener interface {
@@ -2175,7 +2194,7 @@ func AddLbs(lbs []Listener) error {
 }
 
 func isIpvsListener(info LbInfo) bool {
-	if info.Mode != LB_MODE_UDP {
+	if !isIpvsDataPlane(info) {
 		return false
 	}
 
@@ -2196,6 +2215,17 @@ func RefreshLbInternal(cmd *RefreshLbCmd) {
 
 	EnableHaproxyLog = cmd.EnableHaproxyLog
 	for _, lb := range cmd.Lbs {
+		if isTcpIpvsDataPlane(lb) {
+			listener := GetListener(lb)
+			if listener != nil {
+				toDeleted = append(toDeleted, listener)
+			}
+			if len(lb.NicIps) != 0 {
+				ipvsAdded[lb.ListenerUuid] = lb
+			}
+			continue
+		}
+
 		if isIpvsListener(lb) {
 			ipvsAdded[lb.ListenerUuid] = lb
 			continue
@@ -2265,6 +2295,11 @@ func DeleteLbInternal(cmd *deleteLbCmd) {
 	ipvs := map[string]LbInfo{}
 	if len(cmd.Lbs) > 0 {
 		for _, lb := range cmd.Lbs {
+			if isTcpIpvsDataPlane(lb) {
+				ipvs[lb.ListenerUuid] = lb
+				continue
+			}
+
 			if isIpvsListener(lb) {
 				ipvs[lb.ListenerUuid] = lb
 				continue

--- a/plugin/lb.go
+++ b/plugin/lb.go
@@ -2419,7 +2419,7 @@ func NewLbPrometheusCollector() MetricCollector {
 		curSessionNumEntry: prom.NewDesc(
 			"zstack_lb_cur_session_num",
 			"Backend server active session number",
-			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID}, nil,
+			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID, LB_ServerGroup_UUID}, nil,
 		),
 		inByteEntry: prom.NewDesc(
 			"zstack_lb_in_bytes",
@@ -2440,17 +2440,17 @@ func NewLbPrometheusCollector() MetricCollector {
 		refusedSessionNumEntry: prom.NewDesc(
 			"zstack_lb_refused_session_num",
 			"Backend server refused session number",
-			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID}, nil,
+			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID, LB_ServerGroup_UUID}, nil,
 		),
 		totalSessionNumEntry: prom.NewDesc(
 			"zstack_lb_total_session_num",
 			"Backend server total session number",
-			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID}, nil,
+			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID, LB_ServerGroup_UUID}, nil,
 		),
 		concurrentSessionUsageEntry: prom.NewDesc(
 			"zstack_lb_concurrent_session_num",
 			"Backend server session number including active and waiting state session",
-			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID}, nil,
+			[]string{LB_LISTENER_UUID, LB_LISTENER_BACKEND_IP, LB_UUID, LB_ServerGroup_UUID}, nil,
 		),
 		hrsp1xxEntry: prom.NewDesc(
 			"zstack_lb_hrsp1xx",
@@ -2526,10 +2526,10 @@ func TransformToMetric(c *loadBalancerCollector, listenerUuid string, listener L
 		ch <- prom.MustNewConstMetric(c.statusEntry, prom.GaugeValue, float64(cnt.Status), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
 		ch <- prom.MustNewConstMetric(c.inByteEntry, prom.GaugeValue, float64(cnt.bytesIn), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
 		ch <- prom.MustNewConstMetric(c.outByteEntry, prom.GaugeValue, float64(cnt.bytesOut), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
-		ch <- prom.MustNewConstMetric(c.curSessionNumEntry, prom.GaugeValue, float64(cnt.sessionNumber), cnt.listenerUuid, cnt.ip, lbUuid)
-		ch <- prom.MustNewConstMetric(c.refusedSessionNumEntry, prom.GaugeValue, float64(cnt.refusedSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid)
-		ch <- prom.MustNewConstMetric(c.totalSessionNumEntry, prom.GaugeValue, float64(cnt.totalSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid)
-		ch <- prom.MustNewConstMetric(c.concurrentSessionUsageEntry, prom.GaugeValue, float64(cnt.concurrentSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid)
+		ch <- prom.MustNewConstMetric(c.curSessionNumEntry, prom.GaugeValue, float64(cnt.sessionNumber), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
+		ch <- prom.MustNewConstMetric(c.refusedSessionNumEntry, prom.GaugeValue, float64(cnt.refusedSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
+		ch <- prom.MustNewConstMetric(c.totalSessionNumEntry, prom.GaugeValue, float64(cnt.totalSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
+		ch <- prom.MustNewConstMetric(c.concurrentSessionUsageEntry, prom.GaugeValue, float64(cnt.concurrentSessionNumber), cnt.listenerUuid, cnt.ip, lbUuid, cnt.serverGroupUuid)
 	}
 
 	ch <- prom.MustNewConstMetric(c.curSessionUsageEntry, prom.GaugeValue, float64(sessionNum*100/maxSessionNum), listenerUuid, lbUuid)


### PR DESCRIPTION
Integrate the SUG-2795 ZVR data-plane patches for T2 and T6.

Scope:
- Base/target branch: 5.5.28.
- Source branch: codex/sug-2795-integration-5.5.28.
- Includes the confirmed T2 ZVR TCP IPVS data-plane patch.
- Includes the confirmed T6 ZVR metrics/status patch.

Validation:
- GitLab discussion unresolved_count=0.
- Local integration validation previously produced zvr.bin, zvr_x86_64 and ipvsHealthCheck_x86_64.
- Live post-deploy E2E on MN 172.24.241.166 / SLB 192.168.2.223 covered TCP IPVS full_nat listener create, multi backend, multi server group, weight, scheduler, zstack_lb_status and traffic/session metrics, backend delete and listener cleanup.

Deployment note from E2E:
- Runtime replacement must update MN ansible zvr.bin, SLB /home/vyos/zvr.bin, SLB file-lists and /opt/vyatta/sbin runtime binaries, otherwise old zvr.bin can rewrite runtime binaries.

Remaining gate:
- DevOps task/build aggregate PASS/success evidence is still pending.

Test: git diff --check; Go build/test during integration; post-deploy E2E on 172.24.241.166

Resolves: ZSTAC-86152

Change-Id: I910a83a84dbb22be175863037865b5801c24652a

sync from gitlab !1149