### PR TITLE
[ZSTAC-86398] Backport ZSTAC-81286 to 5.4.10

### DIFF
--- a/plugin/auxiliary.go
+++ b/plugin/auxiliary.go
@@ -270,6 +270,13 @@ func SetZebraRoutes(infos []RouteInfo) {
 		err       error
 	)
 
+	changeDefaultRoute := false
+	for _, info := range infos {
+		if info.Destination == "0.0.0.0/0" {
+			changeDefaultRoute = true
+		}
+	}
+
 	// 1. get old routes by load json
 	if utils.IsEuler2203() {
 		routes := utils.GetCurrentRouteEntriesEuler2203(utils.ROUTETABLE_ID_MAIN)
@@ -310,6 +317,11 @@ func SetZebraRoutes(infos []RouteInfo) {
 		}
 
 		if !found {
+			if old.Dst == "0.0.0.0/0" && !changeDefaultRoute {
+				// mn don't want to change default
+				continue
+			}
+
 			if old.NextHop == "" {
 				old.NextHop = "Null0"
 			}


### PR DESCRIPTION
Clone Jira: ZSTAC-86398

Original Jira: ZSTAC-81286

Source fix MR: zstack-vyos!1054

Cherry-picked commit(s): 81f7771fc4582739839262c215ad9081722b4fb2

Target branch: 5.4.10

Validation: cherry-pick completed cleanly on 5.4.10. Full regression was not run locally.

sync from gitlab !1151