### PR TITLE
<fix>[lb]: remove unhealthy ipvs backends

### DIFF
--- a/ipvs_health_check/ipvs_health_check.go
+++ b/ipvs_health_check/ipvs_health_check.go
@@ -204,6 +204,10 @@ func (bs *IpvsHealthCheckBackendServer) Install() {
 func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 	ipvsadmLock.Lock()
 	defer ipvsadmLock.Unlock()
+	bs.uninstallLocked()
+}
+
+func (bs *IpvsHealthCheckBackendServer) uninstallLocked() {
 	bs.status = false
 
 	proto := "-u"
@@ -242,6 +246,22 @@ func (bs *IpvsHealthCheckBackendServer) UnInstall() {
 		Sudo:    true,
 	}
 	b.Run()
+}
+
+func (bs *IpvsHealthCheckBackendServer) EnsureUninstalledIfDown() {
+	bs.ensureUninstalledIfDown(&ipvsadmLock, bs.uninstallLocked)
+}
+
+func (bs *IpvsHealthCheckBackendServer) ensureUninstalledIfDown(locker sync.Locker, uninstall func()) {
+	locker.Lock()
+	defer locker.Unlock()
+
+	if bs.status || isHealthCheckDisabled(bs.HealthCheckProtocol) {
+		return
+	}
+
+	log.Debugf("[ipvsHealthCheck task] ensure down backend %s is uninstalled", bs.getBackendKey())
+	uninstall()
 }
 
 func (bs *IpvsHealthCheckBackendServer) EditBackendServer() {
@@ -460,6 +480,7 @@ func reloadIpvsHealthCheckConfig() {
 	var toCancelled []*IpvsHealthCheckBackendServer
 	var toStarted []*IpvsHealthCheckBackendServer
 	var toInstalled []*IpvsHealthCheckBackendServer
+	var toEnsureDown []*IpvsHealthCheckBackendServer
 
 	func() {
 		gHealthCheckMapLock.Lock()
@@ -505,6 +526,9 @@ func reloadIpvsHealthCheckConfig() {
 					log.Debugf("[ipvsHealthCheck reload] checker: %s not changed", old.getBackendKey())
 				}
 
+				if !old.status {
+					toEnsureDown = append(toEnsureDown, old)
+				}
 			}
 		}
 
@@ -522,6 +546,7 @@ func reloadIpvsHealthCheckConfig() {
 					check.setStatus(true)
 				}
 				gHealthCheckMap[check.getBackendKey()] = check
+				toEnsureDown = append(toEnsureDown, check)
 				toStarted = append(toStarted, check)
 			}
 		}
@@ -542,6 +567,10 @@ func reloadIpvsHealthCheckConfig() {
 
 	for _, check := range toInstalled {
 		check.Install()
+	}
+
+	for _, check := range toEnsureDown {
+		check.EnsureUninstalledIfDown()
 	}
 
 	for _, check := range toStarted {
@@ -580,6 +609,7 @@ func syncIpvsadmWithHealthCheck() {
 	}
 
 	var toInstalled []*IpvsHealthCheckBackendServer
+	var toEnsureDown []*IpvsHealthCheckBackendServer
 
 	func() {
 		gHealthCheckMapLock.Lock()
@@ -607,8 +637,8 @@ func syncIpvsadmWithHealthCheck() {
 					log.Debugf("[ipvsHealthCheck sync] delete backend server %+v", temp.getBackendKey())
 					go temp.UnInstall()
 				} else if gHealthCheckMap[temp.getBackendKey()] != nil && !gHealthCheckMap[temp.getBackendKey()].status {
-					log.Debugf("[ipvsHealthCheck sync] change backend server %+v status up", temp.getBackendKey())
-					gHealthCheckMap[temp.getBackendKey()].setStatus(true)
+					log.Debugf("[ipvsHealthCheck sync] ensure down backend server %+v is uninstalled", temp.getBackendKey())
+					toEnsureDown = append(toEnsureDown, gHealthCheckMap[temp.getBackendKey()])
 				}
 			}
 		}
@@ -630,6 +660,10 @@ func syncIpvsadmWithHealthCheck() {
 
 	for _, gbs := range toInstalled {
 		gbs.Install()
+	}
+
+	for _, gbs := range toEnsureDown {
+		gbs.EnsureUninstalledIfDown()
 	}
 }
 

--- a/ipvs_health_check/ipvs_health_check_test.go
+++ b/ipvs_health_check/ipvs_health_check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 	"zstack-vyos/plugin"
 	"zstack-vyos/utils"
@@ -60,6 +61,16 @@ var _ = Describe("ipvs health check test", func() {
 	bsMap[bs2.getBackendKey()] = &bs2
 	bsMap[bs3.getBackendKey()] = &bs3
 	bsMap[bs4.getBackendKey()] = &bs4
+	hasIpvsBackend := func(key string) bool {
+		ipvsConf, err := plugin.NewIpvsConfFromSave()
+		Expect(err).To(BeNil())
+		for _, fs := range ipvsConf.Services {
+			if fs.BackendServers[key] != nil {
+				return true
+			}
+		}
+		return false
+	}
 
 	fs := plugin.IpvsHealthCheckFrontService{
 		LbUuid:       bs1.LbUuid,
@@ -336,6 +347,59 @@ var _ = Describe("ipvs health check test", func() {
 		time.Sleep(time.Duration(wait) * time.Second)
 		ipvsConf, _ = plugin.NewIpvsConfFromSave()
 		Expect(len(ipvsConf.Services) == 0).To(BeTrue(), fmt.Sprintf("0 ipvs service, actual %d", len(ipvsConf.Services)))
+	})
+
+	It("ipvs health check: reload removes down checker backend from ipvsadm", func() {
+		checker := bs1
+		checker.Install()
+		defer checker.UnInstall()
+		Expect(hasIpvsBackend(checker.getBackendKey())).To(BeTrue(), "backend should be installed before reload")
+
+		checker.setStatus(false)
+		gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{checker.getBackendKey(): &checker}
+		gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		conf := plugin.IpvsHealthCheckConf{
+			Services: []*plugin.IpvsHealthCheckFrontService{{
+				LbUuid:         checker.LbUuid,
+				ListenerUuid:   checker.ListenerUuid,
+				ConnectionType: checker.ConnectionType,
+				ProtocolType:   checker.ProtocolType,
+				Scheduler:      checker.Scheduler,
+				FrontIp:        checker.FrontIp,
+				FrontPort:      checker.FrontPort,
+				BackendServers: []*plugin.IpvsHealthCheckBackendServer{&checker.IpvsHealthCheckBackendServer},
+			}},
+		}
+		utils.JsonStoreConfig(plugin.IPVS_HEALTH_CHECK_CONFIG_FILE, conf)
+
+		reloadIpvsHealthCheckConfig()
+
+		Eventually(func() bool {
+			return hasIpvsBackend(checker.getBackendKey())
+		}, 3*time.Second, 200*time.Millisecond).Should(BeFalse(), "down checker backend should be removed from ipvsadm after reload")
+	})
+
+	It("ipvs health check: sync removes a reintroduced down checker backend", func() {
+		checker := bs1
+		checker.setStatus(false)
+		gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{checker.getBackendKey(): &checker}
+		gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+
+		reintroduced := checker
+		reintroduced.Install()
+		DeferCleanup(func() {
+			reintroduced.UnInstall()
+			gHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+			gDisabledHealthCheckMap = map[string]*IpvsHealthCheckBackendServer{}
+		})
+		Expect(hasIpvsBackend(checker.getBackendKey())).To(BeTrue(), "backend should be reintroduced before sync")
+		Expect(checker.status).To(BeFalse(), "checker must remain down before sync")
+
+		syncIpvsadmWithHealthCheck()
+
+		Eventually(func() bool {
+			return hasIpvsBackend(checker.getBackendKey())
+		}, 3*time.Second, 200*time.Millisecond).Should(BeFalse(), "sync should remove the reintroduced down backend")
 	})
 
 	It("ipvs health check: test ipv6", func() {
@@ -698,3 +762,55 @@ var _ = Describe("ipvs health check test", func() {
 		}
 	})
 })
+
+type blockingTestLocker struct {
+	waiting chan struct{}
+	release chan struct{}
+}
+
+func (l *blockingTestLocker) Lock() {
+	close(l.waiting)
+	<-l.release
+}
+
+func (l *blockingTestLocker) Unlock() {}
+
+func TestEnsureUninstalledIfDownRechecksStatusUnderLock(t *testing.T) {
+	checker := IpvsHealthCheckBackendServer{}
+	checker.HealthCheckProtocol = healthCheckProtocolTCP
+	checker.status = false
+
+	locker := &blockingTestLocker{
+		waiting: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	uninstallCalled := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		checker.ensureUninstalledIfDown(locker, func() {
+			uninstallCalled <- struct{}{}
+		})
+		close(done)
+	}()
+
+	select {
+	case <-locker.waiting:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ensure-down operation did not start waiting for the lock")
+	}
+
+	checker.status = true
+	close(locker.release)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ensure-down operation did not finish after the lock was released")
+	}
+
+	select {
+	case <-uninstallCalled:
+		t.Fatal("backend recovered while waiting for the lock was uninstalled")
+	default:
+	}
+}


### PR DESCRIPTION
Unhealthy TCP IPVS backends are now removed again whenever listener refresh or periodic reconciliation reintroduces them.

## Behavior Change

- A backend whose health checker is already `status=false` remains absent from `ipvsadm` after configuration refresh. Why: a failed backend must not become selectable again until a health check succeeds.
- Periodic IPVS reconciliation removes a real server that belongs to a down checker instead of changing the checker back to up. Why: checker state is the authoritative health result.

## Structural Change

- Reload and reconciliation collect down checkers while holding the checker-map lock, then uninstall their real servers after releasing it. Why: keep checker state and IPVS state consistent without extending the shared lock around shell execution.

## Key Change

```diff
- checker.setStatus(true)
+ checker.EnsureUninstalledIfDown()
```

## Files

- `ipvs_health_check/ipvs_health_check.go`
- `ipvs_health_check/ipvs_health_check_test.go`

## Verified Facts

- `GOFLAGS=-mod=readonly /usr/local/go/bin/go test -vet=off ./ipvs_health_check -run '^$'` passed the package compile check in the integration worktree.
- `GOFLAGS=-mod=readonly make ARCH=amd64 package` produced the deployed `zvr.bin` from the same patch.
- Live verification on SLB VM `6e3eb9dc7bbf4e3da19e1a2ac189e940` confirmed the down backend was absent and was immediately removed after a simulated refresh re-add plus health-check reload.

## Pending Confirmation

- The full local Ginkgo suite requires `ipvsadm-save`; the affected path was verified on the live SLB appliance.

Test: package compile, amd64 build, and live SLB reload verification

Resolves: ZSTAC-87006

Change-Id: I4d0250308c95f0c55c9a44ce7aa07b3f6e8cc431

sync from gitlab !1178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 当后端健康状态为 down 且启用健康检查时，系统会自动从 IPVS 中卸载该后端。
  * 配置重载和同步过程中会统一清理异常后端，避免其继续接收流量。

* **问题修复**
  * 修复后端恢复安装后仍处于 down 状态时未被及时移除的问题。
  * 修复后端在卸载过程中恢复健康时被错误移除的问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->