### PR TITLE
<fix>[route]: ZSTAC-87200 keep MN route on sync

### DIFF
--- a/plugin/route.go
+++ b/plugin/route.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	SYNC_ROUTES = "/syncroutes"
-	GET_ROUTES  = "/getroutes"
+	SYNC_ROUTES                    = "/syncroutes"
+	GET_ROUTES                     = "/getroutes"
+	managementNodeCidrBootstrapKey = "managementNodeCidr"
 )
 
 type RouteInfo struct {
@@ -98,7 +99,7 @@ func SetRoutes(infos []RouteInfo) {
 	}
 
 	for _, o := range oldStaticRoutes {
-		if o.Destination == "0.0.0.0/0" {
+		if isProtectedSystemRoute(o) {
 			continue
 		}
 		delete := true
@@ -139,6 +140,15 @@ func SetRoutes(infos []RouteInfo) {
 	}
 
 	tree.Apply(false)
+}
+
+func isProtectedSystemRoute(route RouteInfo) bool {
+	if route.Destination == "0.0.0.0/0" {
+		return true
+	}
+
+	mgmtNodeCidr, _ := utils.BootstrapInfo[managementNodeCidrBootstrapKey].(string)
+	return mgmtNodeCidr != "" && route.Destination == mgmtNodeCidr
 }
 
 func GetLinuxRoutes() (ret int, output string, stderr string, err error) {

--- a/plugin/route_protection_test.go
+++ b/plugin/route_protection_test.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"testing"
+
+	"zstack-vyos/utils"
+)
+
+func TestIsProtectedSystemRoute(t *testing.T) {
+	originalBootstrapInfo := utils.BootstrapInfo
+	defer func() {
+		utils.BootstrapInfo = originalBootstrapInfo
+	}()
+
+	utils.BootstrapInfo = map[string]interface{}{
+		managementNodeCidrBootstrapKey: "172.24.0.0/16",
+	}
+
+	tests := []struct {
+		name  string
+		route RouteInfo
+		want  bool
+	}{
+		{
+			name: "keeps default route",
+			route: RouteInfo{
+				Destination: "0.0.0.0/0",
+				Target:      "192.168.190.1",
+			},
+			want: true,
+		},
+		{
+			name: "keeps management return route",
+			route: RouteInfo{
+				Destination: "172.24.0.0/16",
+				Target:      "192.168.190.1",
+			},
+			want: true,
+		},
+		{
+			name: "does not keep stale custom route",
+			route: RouteInfo{
+				Destination: "198.51.100.60/32",
+				Target:      "192.168.190.1",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isProtectedSystemRoute(tt.route); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Backport the management return-route protection for VPC routers to 5.4.12. `/syncroutes` must not delete the bootstrap route that returns Cloud management traffic through eth0.

## Changes
- Preserve the default route and the bootstrap `managementNodeCidr` route during stale route cleanup.
- Keep deletion of ordinary stale static routes unchanged.
- Add a focused route-protection unit test without replacing the existing 5.4.12 Ginkgo route test.

## Testing
- [x] Focused `TestIsProtectedSystemRoute`: default, management return, and ordinary stale routes
- [x] `GOROOT=$(go env GOROOT) GOFLAGS=-mod=readonly make -f makefile package ARCH=amd64`
- [ ] CI pipeline
- [ ] Runtime VPC-router regression

Resolves: ZSTAC-87200

sync from gitlab !1182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化静态路由清理逻辑，避免误删除默认路由和管理节点通信所需的路由。
  * 过期的自定义路由仍会按预期清理。

* **测试**
  * 增加路由保护场景测试，覆盖默认路由、管理节点回程路由及过期自定义路由。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->